### PR TITLE
Taskwarrior 0.0.5: Added possibility to specify tags

### DIFF
--- a/taskwarrior/README.md
+++ b/taskwarrior/README.md
@@ -17,6 +17,7 @@ To export a set of tasks, you need to select text, and then click `Export to Tas
 
 * project names should be formatted as headers, and may be nested
 * the tasks are taken only from the unordered list items - lines that are starting with asterisk (*) or minus sign (-)
+* tags for the tasks may be added by specifying `+taskname` at the end of the note. You may do that multiple times.
 * any other content will be skipped - any additional comments or empty lines do not matter during the parsing process.
 
 ### Example
@@ -26,20 +27,20 @@ The following Markdown text:
         ## Project1
         * task one
         ### Subproject1
-        * task two
+        * task two +test
         Some additional portion of text, describing how awesome project 1 is
         * task three
         ### Subproject2
-        * task four
+        * task four +tagged +few +times
         # Project2
         * task five
 
 should generate following calls to Taskwarrior:
 
         task add pro:Project1 task one
-        task add pro:Project1.Subproject1 task two
+        task add pro:Project1.Subproject1 task two tags:"test"
         task add pro:Project1.Subroject1 task three
-        task add pro:Project1.Subproject2 task four
+        task add pro:Project1.Subproject2 task four tags:"tagged few times"
         task add pro:Project2 task five
 
 ## Import (TW -> note)
@@ -71,10 +72,10 @@ will be replaced by:
         # Project1
         * task one
         ## Subproject2
-        * task four
+        * task four +tagged +few +times
         * task four
         ## Subproject1
-        * task two
+        * task two +test
         Something written here.
         # Project3
         # Project2

--- a/taskwarrior/info.json
+++ b/taskwarrior/info.json
@@ -2,7 +2,7 @@
   "name": "Taskwarrior",
   "identifier": "taskwarrior",
   "script": "taskwarrior.qml",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "minAppVersion": "17.06.4",
   "authors": ["@fmakowski"],
   "platforms": ["linux", "macos"],

--- a/taskwarrior/taskwarrior.qml
+++ b/taskwarrior/taskwarrior.qml
@@ -149,10 +149,27 @@ QtObject {
                     
                     var isTask = taskRegExp.exec(line);
                     if (isTask) {
-                        
+                        var tags = [];
                         taskDescription = isTask[1];
                         logIfVerbose("Detected task: " + taskDescription);
+                        var fetchTag;
+                        var tagExp = /^(.+)?[\s*]?\+(.+)$/; 
+                        var currentTaskDescription = taskDescription;
+                        do {
+                            logIfVerbose("Fetching tags...");
+                            fetchTag = tagExp.exec(currentTaskDescription);
+                            if (fetchTag) {
+                                logIfVerbose("Tag " + fetchTag[2] + " found!");
+                                tags.push(fetchTag[2]);
+                                currentTaskDescription = fetchTag[1];
+                                var re = new RegExp("\\+" + fetchTag[2].replace(/ /g, ''), "i");
+                                taskDescription = taskDescription.replace(re,'');
+                            } else
+                                break;
+                        } while(currentTaskDescription);
+                        
                         var concatenatedProjectName = projectName.join('.');
+                        if (tags.length == 0) {
                         logIfVerbose("Executing \"" + taskPath + " add pro:" + concatenatedProjectName + " " + taskDescription + "\"");
                         script.startDetachedProcess(taskPath,
                                                     [
@@ -160,6 +177,16 @@ QtObject {
                                                         "pro:" + concatenatedProjectName,
                                                         taskDescription
                                                     ]);
+                        } else {
+                            logIfVerbose("Executing \"" + taskPath + " add pro:" + concatenatedProjectName + " " + taskDescription + " tags:\"" + tags.join(' ') + "\"\"");
+                        script.startDetachedProcess(taskPath,
+                                                    [
+                                                        "add",
+                                                        "pro:" + concatenatedProjectName,
+                                                        taskDescription,
+                                                        "tags:\"" + tags.join(' ') + "\""
+                                                    ]);
+                        }
                         // We expect, that the task description would be the only thing in the line, hence `return`.
                         return;
                     }
@@ -257,7 +284,46 @@ QtObject {
                             var taskParamsRegexp = /(\d+)[\s*]?(.+)?[\s*]?/i;
                             var fetchTaskParams = taskParamsRegexp.exec(task);
                             logIfVerbose("Extracted data from task: ID " + fetchTaskParams[1] + " Desc: " + fetchTaskParams[2]);
-                            var taskEntry = "* " + fetchTaskParams[2];
+                            
+                            // We are fetching tags to append them to description line
+                            var tagResult = script.startSynchronousProcess(taskPath, 
+                                                                [
+                                                                    fetchTaskParams[1],
+                                                                    "tag"
+                                                                ],
+                                                                "");
+                            
+                            var tagsPlainText = "";
+
+                            if (tagResult) {
+                                var tagsSeparated;
+                                // The result does not contain any \n, so we are splitting by whitespace.
+                                tagsSeparated = tagResult.toString().split('\n');
+                                logIfVerbose(tagsSeparated);
+                                tagsSeparated.splice(0, 1); // removing ""
+                                if (tagsSeparated.length === 0) {
+                                    logIfVerbose("No tags");
+                                    return;
+                                }
+
+                                tagsSeparated.splice(0, 1); // removing headline
+                                tagsSeparated.splice(0, 1); // removing "----"
+
+                                tagsSeparated.splice(tagsSeparated.length - 1, 1); // removing ""
+                                tagsSeparated.splice(tagsSeparated.length - 1, 1); // removing ""
+                                tagsSeparated.splice(tagsSeparated.length - 1, 1); // removing ""
+
+                                logIfVerbose(tagsSeparated);
+                                tagsSeparated.forEach( function(tag){
+
+                                    var tagsRegexp = /[\s*]?(.+)[\s*]?1[\s*]?/i;
+                                    var fetchTag = tagsRegexp.exec(tag);
+                                    tagsPlainText += " +" + fetchTag[1].replace(/ /g,'');
+                                });
+
+                            }
+
+                            var taskEntry = "* " + fetchTaskParams[2] + tagsPlainText;
                             logIfVerbose("Inserting \"" + taskEntry + "\" after line " + projectNameLines[currentProjectNumber - 1]);
                             plainText.splice(projectNameLines[currentProjectNumber - 1], 0, taskEntry);
                             
@@ -268,6 +334,8 @@ QtObject {
                             }
                             // We gather task IDs in case deleteOnImport is enabled.
                             taskIds.push(fetchTaskParams[1]);
+
+                            
                         });
 
                         if (deleteOnImport) {

--- a/taskwarrior/taskwarrior.qml
+++ b/taskwarrior/taskwarrior.qml
@@ -302,22 +302,21 @@ QtObject {
                                 tagsSeparated.splice(0, 1); // removing ""
                                 if (tagsSeparated.length === 0) {
                                     logIfVerbose("No tags");
-                                    return;
+                                } else {
+                                    tagsSeparated.splice(0, 1); // removing headline
+                                    tagsSeparated.splice(0, 1); // removing "----"
+
+                                    tagsSeparated.splice(tagsSeparated.length - 1, 1); // removing ""
+                                    tagsSeparated.splice(tagsSeparated.length - 1, 1); // removing ""
+                                    tagsSeparated.splice(tagsSeparated.length - 1, 1); // removing ""
+
+                                    tagsSeparated.forEach( function(tag){
+
+                                        var tagsRegexp = /[\s*]?(.+)[\s*]?1[\s*]?/i;
+                                        var fetchTag = tagsRegexp.exec(tag);
+                                        tagsPlainText += " +" + fetchTag[1].replace(/ /g,'');
+                                    });
                                 }
-
-                                tagsSeparated.splice(0, 1); // removing headline
-                                tagsSeparated.splice(0, 1); // removing "----"
-
-                                tagsSeparated.splice(tagsSeparated.length - 1, 1); // removing ""
-                                tagsSeparated.splice(tagsSeparated.length - 1, 1); // removing ""
-                                tagsSeparated.splice(tagsSeparated.length - 1, 1); // removing ""
-
-                                tagsSeparated.forEach( function(tag){
-
-                                    var tagsRegexp = /[\s*]?(.+)[\s*]?1[\s*]?/i;
-                                    var fetchTag = tagsRegexp.exec(tag);
-                                    tagsPlainText += " +" + fetchTag[1].replace(/ /g,'');
-                                });
                             }
 
                             var taskEntry = "* " + fetchTaskParams[2] + tagsPlainText;

--- a/taskwarrior/taskwarrior.qml
+++ b/taskwarrior/taskwarrior.qml
@@ -299,7 +299,6 @@ QtObject {
                                 var tagsSeparated;
                                 // The result does not contain any \n, so we are splitting by whitespace.
                                 tagsSeparated = tagResult.toString().split('\n');
-                                logIfVerbose(tagsSeparated);
                                 tagsSeparated.splice(0, 1); // removing ""
                                 if (tagsSeparated.length === 0) {
                                     logIfVerbose("No tags");
@@ -313,14 +312,12 @@ QtObject {
                                 tagsSeparated.splice(tagsSeparated.length - 1, 1); // removing ""
                                 tagsSeparated.splice(tagsSeparated.length - 1, 1); // removing ""
 
-                                logIfVerbose(tagsSeparated);
                                 tagsSeparated.forEach( function(tag){
 
                                     var tagsRegexp = /[\s*]?(.+)[\s*]?1[\s*]?/i;
                                     var fetchTag = tagsRegexp.exec(tag);
                                     tagsPlainText += " +" + fetchTag[1].replace(/ /g,'');
                                 });
-
                             }
 
                             var taskEntry = "* " + fetchTaskParams[2] + tagsPlainText;
@@ -334,8 +331,6 @@ QtObject {
                             }
                             // We gather task IDs in case deleteOnImport is enabled.
                             taskIds.push(fetchTaskParams[1]);
-
-                            
                         });
 
                         if (deleteOnImport) {
@@ -346,9 +341,7 @@ QtObject {
                                 "delete"
                             ]);
                         }
-                        
                     }
-
                 });
 
                 // Finally, selected text is replaced by the text with insertions.


### PR DESCRIPTION
Hi there!

QOwnNotes Taskwarrior script has a new release (0.0.5), and it brings one small, but particularly useful change: possibility to specify tags. You can either add "+tagname" at the end of task entry to be exported, or have "+tagname" appended while importing them. 

The code requires a bit of refactoring, as I started to repeat the code too much, but let it wait till next release.

Best regards!
Filip