### PR TITLE
Add a setting to specify a folder where created journal notes will be placed.

### DIFF
--- a/journal-entry/info.json
+++ b/journal-entry/info.json
@@ -2,7 +2,7 @@
   "name": "Journal entry",
   "identifier": "journal-entry",
   "script": "journal-entry.qml",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "minAppVersion": "17.11.6",
   "authors": ["@pbek", "@sanderboom"],
   "description" : "This script creates a menu item and a button to create or jump to the current date's journal entry."

--- a/journal-entry/journal-entry.qml
+++ b/journal-entry/journal-entry.qml
@@ -48,6 +48,17 @@ QtObject {
         var headline = "Journal " + m.getFullYear() + ("0" + (m.getMonth()+1)).slice(-2) + ("0" + m.getDate()).slice(-2);
 
         var fileName = headline + ".md";
+
+        // Check if we already have a Journal note for today.
+
+        // When a default folder is set, make sure to search in that folder.
+        // This has the highest chance of finding an existing journal note.
+        // Right now we can not search the whole database for a note with this
+        // name / filename.
+        if (defaultFolder && defaultFolder !== '') {
+            script.jumpToNoteSubFolder(defaultFolder);
+        }
+
         var note = script.fetchNoteByFileName(fileName);
 
         // check if note was found


### PR DESCRIPTION
When a default folder is set, make sure to search in that folder.
This has the highest chance of finding an existing journal note.
Right now we can not search the whole database for a note with this
name / filename.

Refs pbek/QOwnNotes#795