### PR TITLE
multiple journals per day

### DIFF
--- a/journal-entry/info.json
+++ b/journal-entry/info.json
@@ -2,8 +2,8 @@
   "name": "Journal entry",
   "identifier": "journal-entry",
   "script": "journal-entry.qml",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "minAppVersion": "17.11.6",
-  "authors": ["@pbek", "@sanderboom"],
+  "authors": ["@pbek", "@sanderboom", "@kantrol"],
   "description" : "This script creates a menu item and a button to create or jump to the current date's journal entry."
 }

--- a/journal-entry/journal-entry.qml
+++ b/journal-entry/journal-entry.qml
@@ -7,6 +7,7 @@ import com.qownnotes.noteapi 1.0
 QtObject {
      property string defaultFolder;
      property string defaultTags;
+     property bool singleJournalPerDay;
 
      property variant settingsVariables: [
         {
@@ -23,13 +24,23 @@ QtObject {
             "type": "string",
             "default": "journal",
         },
+         {
+            "identifier": "singleJournalPerDay",
+            "name": "Single journal per day",
+            "description": "Creates a single journal per day instead of always adding a new journal.",
+            "type": "boolean",
+            "default": "true",
+        },
     ];
 
     /**
      * Initializes the custom action
      */
     function init() {
-        script.registerCustomAction("journalEntry", "Create or open a journal entry", "Journal", "document-new");
+		if (singleJournalPerDay)
+			script.registerCustomAction("journalEntry", "Create or open a journal entry", "Journal", "document-new");
+        else
+			script.registerCustomAction("journalEntry", "Create a journal entry", "Journal", "document-new");        
     }
 
     /**
@@ -46,6 +57,11 @@ QtObject {
         // get the date headline
         var m = new Date();
         var headline = "Journal " + m.getFullYear() + ("0" + (m.getMonth()+1)).slice(-2) + ("0" + m.getDate()).slice(-2);
+        
+        // when the configuration option "singleJournalPerDay" is selected create journal entries including time
+        if (!singleJournalPerDay) {
+			headline = headline + "T"+ ("0" + m.getHours()).slice(-2) + ("0" + m.getMinutes()).slice(-2) + ("0" + m.getSeconds()).slice(-2)
+		}
 
         var fileName = headline + ".md";
 


### PR DESCRIPTION
### What:
Modification of the *journal-entry* script to allow multiple journals per day. The default setting keeps the original behaviour. 
When selected in the settings, each button press creates a new journal entry using the date format yyMMddThhmmss.

### Why:
Making a log of phone calls, i needed a separate entry for each call.

I am not sure about modification in the metafile *info.json* 