### PR TITLE
Add script 'insert-toc'

### DIFF
--- a/insert-toc/info.json
+++ b/insert-toc/info.json
@@ -1,0 +1,10 @@
+{
+  "name": "Insert Table of Contents (TOC)",
+  "identifier": "insert-toc",
+  "script": "insert-toc.qml",
+  "authors": ["@flopp"],
+  "platforms": ["linux", "macos", "windows"],
+  "version": "0.0.1",
+  "minAppVersion": "17.06.2",
+  "description" : "This script scans the current note for headlines, generates a table of contents, and inserts a the TOC into the note."
+}

--- a/insert-toc/insert-toc.qml
+++ b/insert-toc/insert-toc.qml
@@ -1,0 +1,86 @@
+import QtQml 2.2
+import QOwnNotesTypes 1.0
+
+/// Extract a 'table of contents' from the current note's headings and insert 
+/// it into the note.
+
+Script { 
+    property string tocTitle
+    
+    property variant settingsVariables: [
+        {
+            "identifier": "tocTitle",
+            "name": "Title of the table of contents",
+            "description": "",
+            "type": "string",
+            "default": "Table of Contents",
+        },
+    ]
+    
+    function init() {
+        script.registerCustomAction("insertToc", "Insert TOC", "TOC", "", true)
+    }
+    
+    function extractTOC(lines) {
+        var toc = [];
+        for (var n = 0; n < lines.length; n++) {
+            var match = lines[n].match(/^(#+)\s+(.*)$/)
+            if (match) {
+                toc.push({
+                    "depth": match[1].length,
+                    "title": match[2].trim()
+                });
+            }
+        }
+        return toc;
+    }
+    
+    function normalizeDepths(toc) {
+        var min = -1;
+        for (var n = 0; n < toc.length; n++) {
+            var depth = toc[n].depth;
+            if (min < 0 || depth < min) {
+                min = depth;
+            }
+        }
+        for (var n = 0; n < toc.length; n++) {
+            toc[n].depth -= min;
+        }
+        
+        return toc;
+    }
+    
+    function indent(depth) {
+        var s = "";
+        for (var i = 0; i < depth; i++) {
+            s += "    ";
+        }
+        return s;
+    }
+    
+    function customActionInvoked(action) {
+        if (action == "insertToc") {
+            var lines = script.currentNote().noteText.split("\n");
+            var toc = extractTOC(lines);
+            toc = normalizeDepths(toc);
+            
+            script.noteTextEditWrite("\n" + tocTitle + "\n\n");
+            var indexByDepth = {};
+            for (var n = 0; n < toc.length; n++) {
+                indexByDepth[toc[n].depth] = 0;
+            }
+            var lastDepth = 0;
+            for (var n = 0; n < toc.length; n++) {
+                var depth = toc[n].depth;
+                var title = toc[n].title;
+                if (depth > lastDepth) {
+                    indexByDepth[depth] = 1;
+                } else {
+                    indexByDepth[depth] += 1;
+                }
+                lastDepth = depth;
+                script.noteTextEditWrite(indent(depth) + indexByDepth[depth] + ". " + title + "\n");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This script implements pbek/QOwnNotes#761:

1. It scans the current note for headlines (currently only `#`-style headlines),
2. then generates a *table of contents* from the data,
3. and finally inserts the TOC into the note.

The TOC's title is configurable.
The script also creates a menu item ("Insert TOC") and a toolbar button ("TOC").