### PR TITLE
Issue-27: BugFix: html entities breaking rendering in plantuml. BugFi…

### DIFF
--- a/render-plantuml/render-plantuml.qml
+++ b/render-plantuml/render-plantuml.qml
@@ -65,6 +65,8 @@ QtObject {
         while (match != null) {
             var matchedUml = match[1].replace(/\n/gi, "\\n");
             var filePath = workDir + "/" + note.id + "_" + (++index);
+
+            matchedUml = matchedUml.replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/"/g, "\\\"").replace(/&quot;/g, "\\\"").replace(/&amp;/g, "&");
             
             var params = ["-e", "require('fs').writeFileSync('" + filePath + "', \"" + matchedUml + "\", 'utf8');"];
             var result = script.startSynchronousProcess("node", params, html);
@@ -108,7 +110,7 @@ QtObject {
      * @return {string} the modfied html or an empty string if nothing should be modified
      */
     function noteToMarkdownHtmlHook(note, html) {
-        var plantumlSectionRegex = /<pre><code class=\"language-plantuml\"\>([\s\S]*?)<\/pre>/gmi;
+        var plantumlSectionRegex = /<pre><code class=\"language-plantuml\"\>([\s\S]*?)(<\/code>)?<\/pre>/gmi;
         
         var plantumlFiles = extractPlantUmlText(html, plantumlSectionRegex, note);
 


### PR DESCRIPTION
Quickfix for errors since html entities were getting saved as is in uml. Reverting the most obvious ones. There could be many more, need a better way of handling this, but most reliable solutions depend on instance of browser/DOMParser, neither of which are available, so had to go for a crude fix.
Also, it seemed that the <code> html tag was getting picked up as well, removed it if present.