### PR TITLE
encryption-pgp: support multiple recipients

### DIFF
--- a/encryption-pgp/encryption-pgp.qml
+++ b/encryption-pgp/encryption-pgp.qml
@@ -21,8 +21,8 @@ QtObject {
         },
         {
             "identifier": "publicKey",
-            "name": "Public PGP Key",
-            "description": "Please enter your public pgp key:",
+            "name": "Public PGP Keys",
+            "description": "Please enter your ';'-separated public pgp keys or their emails:",
             "type": "string",
             "default": "F5161BD3",
         },
@@ -45,9 +45,17 @@ QtObject {
      * @return the exncrypted or decrypted text
      */
     function encryptionHook(text, password, decrypt) {
+	var encryptCommand = ["--encrypt", "--armor"];
+	// split public keys for gpg call
+	var pubKeys = publicKey.split(';');
+	for (var i = 0; i < pubKeys.length; i++) {
+		encryptCommand.append("-r");
+		encryptCommand.append(pubKeys[i]);
+	}
+
         // encrypt the text for public key or decrypt with gpg
         // decryption will only work if you don't have to enter a password
-        var param = decrypt ? ["--decrypt"] : ["--encrypt", "--armor", "-r", publicKey];
+        var param = decrypt ? ["--decrypt"] : encryptCommand;
         var result = script.startSynchronousProcess(gpgPath, param, text);
         return result;
     }

--- a/encryption-pgp/info.json
+++ b/encryption-pgp/info.json
@@ -2,8 +2,8 @@
   "name": "PGP Encryption",
   "identifier": "encryption-pgp",
   "script": "encryption-pgp.qml",
-  "authors": ["@pbek"],
-  "version": "0.0.1",
+  "authors": ["@pbek", "@ClawOfLight"],
+  "version": "0.0.2",
   "minAppVersion": "17.05.7",
-  "description" : "This script will encrypt and decrypt notes with <a href='https://gnupg.org/'>PGP</a> instead of the internal AES-256 encryption.\nDecryption may only work if you don't have to enter a password."
+  "description" : "This script will encrypt and decrypt notes with <a href='https://gnupg.org/'>PGP</a> instead of the internal AES-256 encryption.\nDecryption may only work if you don't have to enter a password. Find out how to set up gpg-agent on your system."
 }


### PR DESCRIPTION
Like the title says.
Pretty much does what the previous version did, except the corresponding setting is split on `;` and the `gpg` call is adapted accordingly.