### PR TITLE
Extend insert-toc to generate links to sections

### DIFF
--- a/insert-toc/info.json
+++ b/insert-toc/info.json
@@ -4,7 +4,7 @@
   "script": "insert-toc.qml",
   "authors": ["@flopp", "@toindev"],
   "platforms": ["linux", "macos", "windows"],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "minAppVersion": "17.06.2",
   "description" : "This script scans the current note for headlines, generates a table of contents, and inserts a the TOC into the note."
 }

--- a/insert-toc/info.json
+++ b/insert-toc/info.json
@@ -2,7 +2,7 @@
   "name": "Insert Table of Contents (TOC)",
   "identifier": "insert-toc",
   "script": "insert-toc.qml",
-  "authors": ["@flopp"],
+  "authors": ["@flopp", "@toindev"],
   "platforms": ["linux", "macos", "windows"],
   "version": "0.0.1",
   "minAppVersion": "17.06.2",


### PR DESCRIPTION
Followup to pbek/QOwnNotes#761 and qownnotes/scripts/pull/22:

This extends the original script to generate the section links in the TOC.
It has been tested with diacriticals and various special symbols, and seems to behave as expected.

The link generation is disabled by default.

It should fulfill @DutchPete request.