### PR TITLE
meeting-note script - optional parameter:time added

### DIFF
--- a/meeting-note/info.json
+++ b/meeting-note/info.json
@@ -2,8 +2,8 @@
   "name": "Meeting note",
   "identifier": "meeting-note",
   "script": "meeting-note.qml",
-  "authors": ["@pbek", "@sanderboom"],
-  "version": "1.0.0",
+  "authors": ["@pbek", "@sanderboom", "@wiktor2200"],
+  "version": "1.0.1",
   "minAppVersion": "17.05.7",
   "description" : "This script creates a menu item and a button to create or jump to the current date's meeting note."
 }

--- a/meeting-note/meeting-note.qml
+++ b/meeting-note/meeting-note.qml
@@ -38,7 +38,7 @@ QtObject {
             "name": "Time in note name",
             "description": "Add time (HH:mm) in 'Meeting' note name.",
             "type": "boolean",
-            "default": true,
+            "default": false,
         },
     ];
 
@@ -62,11 +62,10 @@ QtObject {
 
         // get the date headline
         var m = new Date();
+        var headline = headlinePrefix + " " + m.getFullYear() + "-" + ("0" + (m.getMonth()+1)).slice(-2) + "-" + ("0" + m.getDate()).slice(-2);
 
         if (timeInNoteName) {
-          var headline = headlinePrefix + " " + m.getFullYear() + "-" + ("0" + (m.getMonth()+1)).slice(-2) + "-" + ("0" + m.getDate()).slice(-2) + "T" + ("0" + m.getHours()).slice(-2) + "." + ("0" + m.getMinutes()).slice(-2);
-        } else {
-          var headline = headlinePrefix + " " + m.getFullYear() + "-" + ("0" + (m.getMonth()+1)).slice(-2) + "-" + ("0" + m.getDate()).slice(-2);
+          headline = headline + "T" + ("0" + m.getHours()).slice(-2) + "." + ("0" + m.getMinutes()).slice(-2);
         }
 
         var fileName = headline + ".md";

--- a/meeting-note/meeting-note.qml
+++ b/meeting-note/meeting-note.qml
@@ -8,6 +8,7 @@ QtObject {
     property string headlinePrefix;
     property string defaultFolder;
     property string defaultTags;
+    property bool timeInNoteName;
 
     // register your settings variables so the user can set them in the script settings
     property variant settingsVariables: [
@@ -32,6 +33,13 @@ QtObject {
             "type": "string",
             "default": "meeting",
         },
+        {
+            "identifier": "timeInNoteName",
+            "name": "Time in note name",
+            "description": "Add time (HH:mm) in 'Meeting' note name.",
+            "type": "boolean",
+            "default": true,
+        },
     ];
 
     /**
@@ -54,7 +62,12 @@ QtObject {
 
         // get the date headline
         var m = new Date();
-        var headline = headlinePrefix + " " + m.getFullYear() + "-" + ("0" + (m.getMonth()+1)).slice(-2) + "-" + ("0" + m.getDate()).slice(-2);
+
+        if (timeInNoteName) {
+          var headline = headlinePrefix + " " + m.getFullYear() + "-" + ("0" + (m.getMonth()+1)).slice(-2) + "-" + ("0" + m.getDate()).slice(-2) + "T" + ("0" + m.getHours()).slice(-2) + "." + ("0" + m.getMinutes()).slice(-2);
+        } else {
+          var headline = headlinePrefix + " " + m.getFullYear() + "-" + ("0" + (m.getMonth()+1)).slice(-2) + "-" + ("0" + m.getDate()).slice(-2);
+        }
 
         var fileName = headline + ".md";
 


### PR DESCRIPTION
I've added optional `time` parameter in `meeting-note` script. It could be useful if you have, more than one meeting a day or with others teams and you don't want to put everything into one bucket.