### PR TITLE
Compat with tagging in note text

### DIFF
--- a/render-plantuml/render-plantuml.qml
+++ b/render-plantuml/render-plantuml.qml
@@ -16,6 +16,7 @@ QtObject {
     property string plantumlJarPath;
     property string workDir;
     property string hideMarkup;
+    property string noStartUml;
     property string additionalParams;
 
     // register your settings variables so the user can set them in the script settings
@@ -49,6 +50,13 @@ QtObject {
             "default": false
         },
         {
+            "identifier": "noStartUml",
+            "name": "No need for @startuml/@enduml",
+            "description": "Enable if you don't want to add yourself @startuml/@enduml to your plantUml code (compat with tagging in note text)",
+            "type": "boolean",
+            "default": false
+        },
+        {
             "identifier": "additionalParams",
             "name": "Additional Params (Advanced)",
             "description": "Enter any additional parameters you wish to pass to plantuml. This can potentially cause unexpected behaviour:",
@@ -67,12 +75,16 @@ QtObject {
             var filePath = workDir + "/" + note.id + "_" + (++index);
 
             matchedUml = matchedUml.replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/"/g, "\\\"").replace(/&quot;/g, "\\\"").replace(/&amp;/g, "&");
-            
+
+            if (noStartUml == "true") {
+                matchedUml = "@startuml\\n" + matchedUml + "@enduml\\n";
+            }
+
             var params = ["-e", "require('fs').writeFileSync('" + filePath + "', \"" + matchedUml + "\", 'utf8');"];
             var result = script.startSynchronousProcess("node", params, html);
 
             plantumlFiles.push(filePath);
-            
+
             match = plantumlSectionRegex.exec(html);
         }
 


### PR DESCRIPTION
PlantUML was not compatible with tagging in note text (@startuml and @enduml was transformed into a tag before PlantUML). I added an option to automatically add @plantuml/@enduml to remain compatible.