### PR TITLE
 Compat with tagging in note text (v2 !)

### DIFF
--- a/render-plantuml/info.json
+++ b/render-plantuml/info.json
@@ -3,7 +3,7 @@
   "identifier": "render-plantuml",
   "script": "render-plantuml.qml",
   "authors": ["@nikhilw"],
-  "version": "0.0.4",
+  "version": "0.0.5",
   "minAppVersion": "17.05.7",
   "description" : "This script renders any plantuml text embedded in a note with the language hint, into a uml diagram.\n\nIt needs node.js (<a href=\"https://nodejs.org/en/download/\">https://nodejs.org/en/download/</a>), java (<a href=\"https://java.com/en/download/\">https://java.com/en/download/</a>) and plantuml (<a href=\"http://plantuml.com/download\">http://plantuml.com/download</a>) to be installed. Install node and java. download the plantuml jar and provide the full path in script settings.\n\nWARNING: As it needs to launch a synchronous java process to convert the diagrams to images, it adds a certain delay depending on your machine's configuration."
 }

--- a/render-plantuml/render-plantuml.qml
+++ b/render-plantuml/render-plantuml.qml
@@ -16,6 +16,7 @@ QtObject {
     property string plantumlJarPath;
     property string workDir;
     property string hideMarkup;
+    property string noStartUml;
     property string additionalParams;
 
     // register your settings variables so the user can set them in the script settings
@@ -49,6 +50,13 @@ QtObject {
             "default": false
         },
         {
+            "identifier": "noStartUml",
+            "name": "No need for @startuml/@enduml",
+            "description": "Enable if you don't want to add @startuml/@enduml to your plantUml code (compat with tagging in note text)",
+            "type": "boolean",
+            "default": true
+        },
+        {
             "identifier": "additionalParams",
             "name": "Additional Params (Advanced)",
             "description": "Enter any additional parameters you wish to pass to plantuml. This can potentially cause unexpected behaviour:",
@@ -66,13 +74,21 @@ QtObject {
             var matchedUml = match[1].replace(/\n/gi, "\\n");
             var filePath = workDir + "/" + note.id + "_" + (++index);
 
+
+            if (noStartUml == "true") {
+                // Remove @startuml/@enduml if they were "tagged"
+                matchedUml = matchedUml.replace(/^<b><font color=\"\w+\">startuml<\/font><\/b>\\n/gi, "").replace(/<b><font color=\"\w+\">enduml<\/font><\/b>\\n$/gi, "");
+                // Add @startuml/@enduml
+                matchedUml = "@startuml\\n" + matchedUml + "@enduml\\n";
+            }
+
             matchedUml = matchedUml.replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/"/g, "\\\"").replace(/&quot;/g, "\\\"").replace(/&amp;/g, "&");
-            
+
             var params = ["-e", "require('fs').writeFileSync('" + filePath + "', \"" + matchedUml + "\", 'utf8');"];
             var result = script.startSynchronousProcess("node", params, html);
 
             plantumlFiles.push(filePath);
-            
+
             match = plantumlSectionRegex.exec(html);
         }
 


### PR DESCRIPTION
PlantUML was not compatible with tagging in note text (@startuml and @enduml were transformed into a tag before PlantUML). I added an option to automatically add @plantuml/@enduml to remain compatible.
This version is also compatible with previously added (or copied/pasted) @plantuml/@enduml transformed to tags. Henceforth, fully compatible, the option is checked by default.