### PR TITLE
Script for fixing line numbers in ordered lists

### DIFF
--- a/fix-list-numbers/fix-list-numbers.qml
+++ b/fix-list-numbers/fix-list-numbers.qml
@@ -1,0 +1,59 @@
+import QtQml 2.0
+import QOwnNotesTypes 1.0
+
+/**
+ * This script fixes numbers in ordered list.
+ */
+QtObject {
+    /**
+     * Initializes the custom action
+     */
+    function init() {
+        // create a menu entry
+        script.registerCustomAction("fixListNumbers", "Fix list numbers", "Dummy", "view-sort-ascending", true, true);
+    }
+
+    /**
+     * This function is invoked when a custom action is triggered
+     * in the menu or via button
+     * 
+     * @param identifier string the identifier defined in registerCustomAction
+     */
+    function customActionInvoked(identifier) {
+        if (identifier != 'fixListNumbers') {
+            return;
+        }
+
+        var text = script.noteTextEditSelectedText();
+        var indentGroups = [];
+        var numberRegex = /^(\s*)(\d+)\./;
+
+        var mapped = text.split("\n")
+            .map(function (line) {
+                if (!numberRegex.test(line)) {
+                    return line;
+                }
+
+                var execResults = numberRegex.exec(line);
+                var spacing = (execResults ? execResults[1] : '').replace(new RegExp("\t", 'g'), '    ');
+                var indentLevel = spacing.length;
+                var group = indentGroups.pop() || {level: indentLevel, number: 1};
+
+                if (indentLevel < group.level) {
+                    group = indentGroups.pop();
+                } else if (indentLevel > group.level) {
+                    // this group is for previous indentation level
+                    // push it back to the list
+                    indentGroups.push(group);
+                    group = {level: indentLevel, number: 1};
+                }
+
+                var newLine = line.replace(numberRegex, '$1' + group.number + '.');
+                indentGroups.push({level: indentLevel, number: group.number + 1});
+
+                return newLine;
+            });
+
+        script.noteTextEditWrite(mapped.join("\n"));
+    }
+}

--- a/fix-list-numbers/info.json
+++ b/fix-list-numbers/info.json
@@ -1,0 +1,10 @@
+{
+  "name": "Fix list numbers",
+  "identifier": "fixListNumbers",
+  "script": "fix-list-numbers.qml",
+  "authors": ["@radmen"],
+  "platforms": ["linux", "macos", "windows"],
+  "version": "1.0.0",
+  "minAppVersion": "18.04.3",
+  "description" : "This script fixes numbers in ordered lists."
+}

--- a/fix-list-numbers/info.json
+++ b/fix-list-numbers/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Fix list numbers",
-  "identifier": "fixListNumbers",
+  "identifier": "fix-list-numbers",
   "script": "fix-list-numbers.qml",
   "authors": ["@radmen"],
   "platforms": ["linux", "macos", "windows"],


### PR DESCRIPTION
This relates to: https://github.com/pbek/QOwnNotes/issues/1276

Turned out that it's annoying for me that I need to constantly fix the numbering so I decided to follow @pbek advice and create a script for that.

Tested locally, seems to work correctly.