### PR TITLE
Adapt the plugin to quoted text escaping new behavior of QOwnNotes

### DIFF
--- a/render-plantuml/info.json
+++ b/render-plantuml/info.json
@@ -3,7 +3,7 @@
   "identifier": "render-plantuml",
   "script": "render-plantuml.qml",
   "authors": ["@nikhilw"],
-  "version": "0.0.6",
+  "version": "0.0.7",
   "minAppVersion": "17.05.7",
   "description" : "This script renders any plantuml text embedded in a note with the language hint, into a uml diagram.\n\nIt needs node.js (<a href=\"https://nodejs.org/en/download/\">https://nodejs.org/en/download/</a>), java (<a href=\"https://java.com/en/download/\">https://java.com/en/download/</a>) and plantuml (<a href=\"http://plantuml.com/download\">http://plantuml.com/download</a>) to be installed. Install node and java. download the plantuml jar and provide the full path in script settings.\n\nWARNING: As it needs to launch a synchronous java process to convert the diagrams to images, it adds a certain delay depending on your machine's configuration."
 }

--- a/render-plantuml/info.json
+++ b/render-plantuml/info.json
@@ -3,7 +3,7 @@
   "identifier": "render-plantuml",
   "script": "render-plantuml.qml",
   "authors": ["@nikhilw"],
-  "version": "0.0.5",
+  "version": "0.0.6",
   "minAppVersion": "17.05.7",
   "description" : "This script renders any plantuml text embedded in a note with the language hint, into a uml diagram.\n\nIt needs node.js (<a href=\"https://nodejs.org/en/download/\">https://nodejs.org/en/download/</a>), java (<a href=\"https://java.com/en/download/\">https://java.com/en/download/</a>) and plantuml (<a href=\"http://plantuml.com/download\">http://plantuml.com/download</a>) to be installed. Install node and java. download the plantuml jar and provide the full path in script settings.\n\nWARNING: As it needs to launch a synchronous java process to convert the diagrams to images, it adds a certain delay depending on your machine's configuration."
 }

--- a/render-plantuml/render-plantuml.qml
+++ b/render-plantuml/render-plantuml.qml
@@ -76,13 +76,15 @@ QtObject {
 
 
             if (noStartUml == "true") {
-                // Remove @startuml/@enduml if they were "tagged"
-                matchedUml = matchedUml.replace(/^<b><font color=\"\w+\">startuml<\/font><\/b>\\n/gi, "").replace(/<b><font color=\"\w+\">enduml<\/font><\/b>\\n$/gi, "");
-                // Add @startuml/@enduml
+				// Transforms back tagged start/end keywords to @startkeyword/@endkeyword
+                matchedUml = matchedUml.replace(/^<b><font color=\"\w+\">(start\w+)<\/font><\/b>\\n/gi, "@$1\\n").replace(/<b><font color=\"\w+\">(end\w+)<\/font><\/b>\\n$/gi, "@$1\\n");
+
+                // If needed adds @startuml/@enduml
+                if (!(matchedUml.match(/^@start\w+\\n/gi) && matchedUml.match(/\\n@end\w+\\n$/gi)))
                 matchedUml = "@startuml\\n" + matchedUml + "@enduml\\n";
             }
 
-            matchedUml = matchedUml.replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/"/g, "\\\"").replace(/&quot;/g, "\\\"").replace(/&amp;/g, "&");
+            matchedUml = matchedUml.replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/"/g, "\\\"").replace(/&quot;/g, "\\\"").replace(/&amp;/g, "&").replace(/&#39;/g,"'");
 
             var params = ["-e", "require('fs').writeFileSync('" + filePath + "', \"" + matchedUml + "\", 'utf8');"];
             var result = script.startSynchronousProcess("node", params, html);


### PR DESCRIPTION
QOwnNotes has a new behavior for quoted text: all special characters are escaped in numerical entities (cf. https://github.com/pbek/QOwnNotes/issues/1643). This is not compatible with PlantUML.

I made some changes to unescape text and preserve \n