### PR TITLE
Critic Markup changes to handle multiline comments

### DIFF
--- a/critic-markup/info.json
+++ b/critic-markup/info.json
@@ -4,7 +4,7 @@
   "script": "critic-markup.qml",
   "authors": ["@mleo2003", "@ryliejamesthomas, @Beurt"],
   "platforms": ["linux", "macos", "windows"],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "minAppVersion": "20.6.0",
   "description" : "Provide a way to highlight text with Critic Markup (only in the preview at the moment). Learn more about Critic Markup on their website : http://criticmarkup.com/."
 }


### PR DESCRIPTION
Big changes to the way Critic Markup was interpreted in order to have multiline highlights. Also added classes to link mark tags to span tags and del tags to ins tags.

Now, it works like that:

```html
{--<p>This is a </p><p>multiline example</p>--}
```

Will render

```html
<p><del>This is a </del></p><p><del>mutliline example</del></p>