### PR TITLE
Closer to the official Critic Markup spec

### DIFF
--- a/critic-markup/critic-markup.qml
+++ b/critic-markup/critic-markup.qml
@@ -65,15 +65,14 @@ QtObject {
 		// Resetting the critic markups' counter
 		script.setPersistentVariable("criticMarkup/classNum", 0);
 		
-		// replace {++something++} to <ins class='critic_markup_##'>something</ins>
-		html = html.replace(/((?:<\w+?>)*?)\{\+\+([\s\S]+?)\+\+\}/gm, wrapInsIntoTags);
-		
-		// replace {--something--} to <del class='critic_markup_##'>something</del>
-		html = html.replace(/((?:<\w+?>)*?)\{\-\-([\s\S]+?)((?:<\w+?>)*?)\-\-\}/gm, wrapDelIntoTags);
+		// replace {~~something~>\n\n~~}
+		// to <del class='critic_markup_##'>something</del></p><ins class="break critic_markup_##">&nbsp;</ins><p>
+		// FIXME [\s\S] si too greedy (because of the spaces ???) and get everything until the last ~&gt;
+		// html = html.replace(/((?:<\w+?>)*?)\{(?:<s>|~~)([\s\S]+?)~&gt;((?:\s*?(?:<\/p>\s*?<p>))+?)(?:<\/s>|~~)\}/, wrapReplacementsByPIntoTags);
 		
 		// replace {~~something~>something else~~}
 		// to <del class='critic_markup_##'>something</del><ins class='critic_markup_##'>something else</ins>
-		html = html.replace(/((?:<\w+?>)*?)\{(?:<s>|~~)([\s\S]*?)\~&gt;([\s\S]*?)(?:<\/s>|~~)\}/gm, wrapReplacementsIntoTags);
+		html = html.replace(/((?:<\w+?>)*?)\{(?:<s>|~~)([\s\S]+?)~&gt;([\s\S]*?)(?:<\/s>|~~)\}/gm, wrapReplacementsIntoTags);
 		
 		// replace {==something==}{>>something else<<}
 		// to <mark class='critic_markup_##'>something</mark><span class='critic comment critic_markup_##'>something else</span>
@@ -81,9 +80,21 @@ QtObject {
 		
 		// replace {>>something<<} to <span class='critic comment critic_markup_##'>something</span>
 		html = html.replace(/((?:<\w+?>)*?)\{(?:&gt;&gt;|>>)([\s\S]+?)(?:&lt;&lt;|<<)\}/gm, wrapComsIntoTags);
+
+		// replace {++\n\n++} to </p><ins class='break'>&nbsp;</ins><p>
+		html = html.replace(/\{\+\+(?:\s*?)((?:<\/p>\s*?<p>)+?)\+\+\}/gm,"</p>\n\n<ins class='break'>&nbsp;</ins>\n\n<p>");
+		
+		// replace {++something++} to <ins class='critic_markup_##'>something</ins>
+		html = html.replace(/((?:<\w+?>)*?)\{\+\+([\s\S]+?)\+\+\}/gm, wrapInsIntoTags);
+
+		// replace {--\n\n--} to <del>&nbsp;</del>
+		html = html.replace(/\{\-\-(?:\s*?(?:<\/p>\s*?<p>))+?\-\-\}/gm,"<del>&nbsp;</del>");
+		
+		// replace {--something--} to <del class='critic_markup_##'>something</del>
+		html = html.replace(/((?:<\w+?>)*?)\{\-\-([\s\S]+?)((?:<\w+?>)*?)\-\-\}/gm, wrapDelIntoTags);
 		
 		// Setting the styles for the preview
-		var stylesheet = "span.critic.comment {background-color:" + commentsBackgroundColor + "; padding-left: 4px; border-left: 4px solid "+ commentsHightlightsColor +"; } del {color: "+ commentsDeletionColor +" ; text-decoration: line-through;} ins {color: "+ commentsAdditionColor +" ; text-decoration: underline;} mark {background-color:" + commentsHightlightsColor + ";}";
+		var stylesheet = "span.critic.comment, span.critic.metadata {background-color:" + commentsBackgroundColor + "; padding-left: 4px; border-left: 4px solid "+ commentsHightlightsColor +"; } del {color: "+ commentsDeletionColor +" ; text-decoration: line-through;} ins {color: "+ commentsAdditionColor +" ; text-decoration: underline;} ins.break {background-color: " + commentsAdditionColor + "} mark {background-color:" + commentsHightlightsColor + ";}";
 		
 		html = html.replace("</style>", stylesheet + "</style>");
 		return html;
@@ -98,6 +109,13 @@ QtObject {
 		script.setPersistentVariable("criticMarkup/classNum", script.getPersistentVariable("criticMarkup/classNum",0) + 1);
 		return nestTags("ins",caught,preTags,content)
 	}
+	function wrapReplacementsByPIntoTags(caught,preTags,del,ins) {
+		// Increments the markup class number
+		script.setPersistentVariable("criticMarkup/classNum", script.getPersistentVariable("criticMarkup/classNum",0) + 1);
+		var toReturn = nestTags("del",caught,preTags,del);
+		toReturn = toReturn + '\n\n</p><ins class="break' + classPrefix + script.getPersistentVariable("criticMarkup/classNum", 0) + '">&nbsp;</ins>\n\n<p>';
+		return toReturn
+	}
 	function wrapReplacementsIntoTags(caught,preTags,del,ins) {
 		// Increments the markup class number
 		script.setPersistentVariable("criticMarkup/classNum", script.getPersistentVariable("criticMarkup/classNum",0) + 1);
@@ -108,7 +126,7 @@ QtObject {
 	function wrapHightlightsIntoTags(caught,preTags,content,comments) {
 		script.setPersistentVariable("criticMarkup/classNum", script.getPersistentVariable("criticMarkup/classNum",0) + 1);
 		var toReturn = nestTags("mark",caught,preTags,content);
-		toReturn = toReturn + nestTags("span class='critic comment",caught,"",comments);
+		toReturn = toReturn + nestTags("span class='critic metadata",caught,"",comments);
 		return toReturn;
 	}
 	function wrapComsIntoTags(caught,preTags,content) {

--- a/critic-markup/info.json
+++ b/critic-markup/info.json
@@ -4,7 +4,7 @@
   "script": "critic-markup.qml",
   "authors": ["@mleo2003", "@ryliejamesthomas, @Beurt"],
   "platforms": ["linux", "macos", "windows"],
-  "version": "0.0.2",
+  "version": "0.0.3",
   "minAppVersion": "20.6.0",
   "description" : "Provide a way to highlight text with Critic Markup (only in the preview at the moment). Learn more about Critic Markup on their website : http://criticmarkup.com/."
 }


### PR DESCRIPTION
We are still not exactly as the spec for 2 reasons:

1. I introduced (previous commit) a multi-line markup possibility that is not in the spec but that is quite handy
2. I am still struggling with a too greedy regex (L. 71) to deal with {~~something~>\n\n~~}