### PR TITLE
Aganel's Windows patch for Latex Math

### DIFF
--- a/latex-math/info.json
+++ b/latex-math/info.json
@@ -2,9 +2,9 @@
   "name": "Latex Math",
   "identifier": "latex-math",
   "script": "latex-math.qml",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "platforms": ["linux", "macos", "windows"],
   "minAppVersion": "20.8.0",
-  "authors": ["@r00tr4v3n"],
+  "authors": ["@r00tr4v3n","Aganel"],
   "description" : "This script creates LaTex images on the fly with KLatexFormula. e. g. $x^2$ or $[22] x^2$ to create larger images. \nThe images are created once and reused as long as the formula does not change. If you changed the preamble you have to clean the cache folder to regenerate the images. \nDon't make it too complicated, this size works though: $[33] \\frac{1}{2\\pi}\\int{-\\infty}^{\\infty}e^{-\\frac{x^2}{a}}dx$\nHint: You might want to add the $-signs after writing the formula to prevent intermediate image generation."
 }

--- a/latex-math/info.json
+++ b/latex-math/info.json
@@ -5,6 +5,6 @@
   "version": "0.0.6",
   "platforms": ["linux", "macos", "windows"],
   "minAppVersion": "20.8.0",
-  "authors": ["@r00tr4v3n","Aganel"],
+  "authors": ["@r00tr4v3n","@Aganel"],
   "description" : "This script creates LaTex images on the fly with KLatexFormula. e. g. $x^2$ or $[22] x^2$ to create larger images. \nThe images are created once and reused as long as the formula does not change. If you changed the preamble you have to clean the cache folder to regenerate the images. \nDon't make it too complicated, this size works though: $[33] \\frac{1}{2\\pi}\\int{-\\infty}^{\\infty}e^{-\\frac{x^2}{a}}dx$\nHint: You might want to add the $-signs after writing the formula to prevent intermediate image generation."
 }

--- a/latex-math/latex-math.qml
+++ b/latex-math/latex-math.qml
@@ -169,7 +169,7 @@ QtObject {
         const exec = executable
         const preamble = Qt.btoa(getPreamble())
         const quiet = " --quiet 1"; // --quiet OFF does not work (klatexformula bug?)
-        const cmd = `${exec} -f '${formulaColor}' -b '${formulaBgColor}' --base64arg --preamble="${preamble}" --base64arg --latexinput="${latexBase64}" --dpi ${settingDPI} ${quiet} --output ${path}`
+        const cmd = `${exec} -f "${formulaColor}" -b "${formulaBgColor}" --base64arg --preamble="${preamble}" --base64arg --latexinput="${latexBase64}" --dpi ${settingDPI} ${quiet} --output ${path}`
         //log("cmd: "+cmd)
         return cmd
     }

--- a/latex-math/latex-math.qml
+++ b/latex-math/latex-math.qml
@@ -144,8 +144,11 @@ QtObject {
                 //execBashDetached(bashCmd, true)
                 cmdList.push([count, path, bashCmd])
             }
-
-            return `<img style='vertical-align: bottom;' height='${imageSize}' src="file://${path}" alt="LaTex">`; //style='vertical-align: middle;'
+			
+			// we need third slash after file:// if path contains drive letter (e.g. c:) in Windows
+			const thirdSlash = script.platformIsWindows() && path.indexOf(":")===1 ? "/" : "";
+			
+			return `<img style='vertical-align: bottom;' height='${imageSize}' src="file://${thirdSlash}${path}" alt="LaTex">`; //style='vertical-align: middle;'
         });
         if (cmdList.length > 0) {
             execBashList(cmdList); // use a 'thread pool'

--- a/latex-math/latex-math.qml
+++ b/latex-math/latex-math.qml
@@ -169,7 +169,7 @@ QtObject {
         const exec = executable
         const preamble = Qt.btoa(getPreamble())
         const quiet = " --quiet 1"; // --quiet OFF does not work (klatexformula bug?)
-        const cmd = `${exec} -f "${formulaColor}" -b "${formulaBgColor}" --base64arg --preamble="${preamble}" --base64arg --latexinput="${latexBase64}" --dpi ${settingDPI} ${quiet} --output ${path}`
+        const cmd = `"${exec}" -f "${formulaColor}" -b "${formulaBgColor}" --base64arg --preamble="${preamble}" --base64arg --latexinput="${latexBase64}" --dpi ${settingDPI} ${quiet} --output ${path}`
         //log("cmd: "+cmd)
         return cmd
     }
@@ -202,12 +202,12 @@ QtObject {
      * @return the result or [true/false] if detached = true
      */
     function execBashList(cmdList) {
-        const exec = "bash"
+        const exec = script.platformIsWindows() ? "cmd" : "bash";
         log("got cmds: " + cmdList.length)
         if (cmdList.length > 0) {
             const cmd = cmdList.pop();
-            const param = ["-c", cmd[2]]
-            log("exec no: " + cmd[0] + " " + cmd)
+            const param = script.platformIsWindows() ? ["/c", "\""+cmd[2]+"\""] : ["-c", cmd[2]];
+            log("exec" + cmd[0] + ": " + [exec, param.join(" ")].join(" "))
             script.startDetachedProcess(exec, param, "callback-latex-math", cmdList);
         }
     }

--- a/latex-math/latex-math.qml
+++ b/latex-math/latex-math.qml
@@ -1,6 +1,5 @@
 import QtQml 2.13
 import com.qownnotes.noteapi 1.0
-import QtQuick 2.0
 
 
 /**
@@ -100,7 +99,6 @@ QtObject {
      */
     function init() {
         log("init")
-        var result = script.startSynchronousProcess("mkdir", ["-p", workDir]);
         // create a menu entry to paste Latex code as an image
         script.registerCustomAction("latex-math-refresh", "Refresh LaTex Images", "Latex", "view-refresh");
         workDir = script.cacheDir("latex-math");
@@ -197,15 +195,6 @@ QtObject {
             }
         }
     }
-
-    /**
-     * check for a file
-     *
-     */
-    function fileExists(path) {
-        return execBash(`test -f ${path}`)
-    }
-
 
     /**
      * This function invokes a bash command

--- a/latex-math/latex-math.qml
+++ b/latex-math/latex-math.qml
@@ -214,19 +214,6 @@ QtObject {
     }
 
     /**
-     * This function invoces a bash command
-     * @return [true/false] or the resultSet
-     */
-    function execBash(cmd, getResult = false) {
-        const prefix = "2>&1 " // use 2>&1 to redirect stderr to stdout and use as error msg
-        const exec = "bash"
-        const successSuffix = getResult ? "" : " && echo 1 || echo 0"
-        const param = ["-c", prefix + cmd + successSuffix]
-        var result = script.startSynchronousProcess(exec, param);
-        return getResult ? String(result) : result == 1
-    }
-
-    /**
      * This function is invoked when a custom action is triggered
      * in the menu or via button
      *

--- a/latex-math/latex-math.qml
+++ b/latex-math/latex-math.qml
@@ -202,12 +202,13 @@ QtObject {
      * @return the result or [true/false] if detached = true
      */
     function execBashList(cmdList) {
-        const exec = script.platformIsWindows() ? "cmd" : "bash";
+        const linuxExec = "bash";
         log("got cmds: " + cmdList.length)
         if (cmdList.length > 0) {
             const cmd = cmdList.pop();
-            const param = script.platformIsWindows() ? ["/c", "\""+cmd[2]+"\""] : ["-c", cmd[2]];
-            log("exec" + cmd[0] + ": " + [exec, param.join(" ")].join(" "))
+			const exec = script.platformIsWindows() ? cmd[2] : linuxExec;
+            const param = script.platformIsWindows() ? [] : ["-c", cmd[2]];
+            log("exec" + cmd[0] + ": " + exec)
             script.startDetachedProcess(exec, param, "callback-latex-math", cmdList);
         }
     }


### PR DESCRIPTION
Fixed image generation and display of TeX formula preview (Latex Math) for Windows platform.
Removed unused code (import QtQuick, local fileExists, execBash)

I tried to make little to none changes on the linux "side" of the code, but one has to test it on Linux platform to be sure it's ok.