### PR TITLE
Add support for mermaid.js diagrams

### DIFF
--- a/mermaid/info.json
+++ b/mermaid/info.json
@@ -1,0 +1,10 @@
+{
+  "name": "Mermaid Diagrams",
+  "identifier": "mermaid",
+  "script": "mermaid.qml",
+  "authors": ["@dohliam"],
+  "platforms": ["linux", "macos", "windows"],
+  "version": "0.0.1",
+  "minAppVersion": "20.6.0",
+  "description" : "Support for rendering mermaid diagrams."
+}

--- a/mermaid/mermaid.qml
+++ b/mermaid/mermaid.qml
@@ -1,0 +1,30 @@
+import QtQml 2.0
+import QOwnNotesTypes 1.0
+
+QtObject {
+    /**
+     * This function is called when the markdown html of a note is generated
+     *
+     * It allows you to modify this html
+     * This is for example called before by the note preview
+     *
+     * The method can be used in multiple scripts to modify the html of the preview
+     *
+     * @param {NoteApi} note - the note object
+     * @param {string} html - the html that is about to being rendered
+     * @param {string} forExport - the html is used for an export, false for the preview
+     * @return {string} the modified html or an empty string if nothing should be modified
+     */
+
+    function preNoteToMarkdownHtmlHook(note, markdown, forExport) {
+        var re = /```mermaid\n([\s\S]*?)\n```/gim;
+        markdown = markdown.replace(re, function(_, diag){
+            var normalize = diag.replace(/&gt;/gi, ">").replace(/&lt;/gi, "<");
+            var encodedData = Qt.btoa(normalize);
+            var ink = '![](https://mermaid.ink/img/' + encodedData + ')';
+            return ink;
+        });
+        return markdown;
+    }
+
+}


### PR DESCRIPTION
This script adds support for rendering mermaid.js diagrams using the [mermaid.ink](https://mermaid.ink/) API. Details can be found on the [wiki page](https://dohliam.github.io/qownnotes-scripting/scripts/mermaid.html) for the script, and there are a number of example diagrams [here](https://dohliam.github.io/qownnotes-scripting/diagrams/diagrams.html) to show the results.

As noted on the wiki page, this should be considered a temporary workaround until full mermaid support becomes available, but it works reasonably well in the meantime.