### PR TITLE
Add support for wiki-links

### DIFF
--- a/wiki-links/info.json
+++ b/wiki-links/info.json
@@ -1,0 +1,10 @@
+{
+  "name": "Wiki Links",
+  "identifier": "wiki-links",
+  "script": "wiki-links.qml",
+  "authors": ["@dohliam"],
+  "platforms": ["linux", "macos", "windows"],
+  "version": "0.0.1",
+  "minAppVersion": "20.6.0",
+  "description" : "Support for wiki-style internal links (e.g., [[link]])."
+}

--- a/wiki-links/wiki-links.qml
+++ b/wiki-links/wiki-links.qml
@@ -1,0 +1,128 @@
+import QtQml 2.0
+import QOwnNotesTypes 1.0
+
+QtObject {
+    property bool wikilinksSanitizeFilename;
+    property bool wikilinksRemoveSpaces;
+    property bool wikilinksLowerCase;
+    property string wikilinksReplaceSpacesSymbol;
+    property bool wikilinksHideSubfolder;
+    property string wikilinksBackgroundColor;
+    property string wikilinksForegroundColor;
+
+    property variant settingsVariables: [
+        {
+            "identifier": "wikilinksSanitizeFilename",
+            "name": "Wiki Links Sanitize Filename",
+            "description": "Remove all symbols from linked filenames.",
+            "type": "boolean",
+            "default": true,
+        },
+        {
+            "identifier": "wikilinksRemoveSpaces",
+            "name": "Wiki Links Remove Spaces",
+            "description": "Remove or replace spaces from linked filenames.",
+            "type": "boolean",
+            "default": true,
+        },
+        {
+            "identifier": "wikilinksLowerCase",
+            "name": "Wiki Links Lower Case",
+            "description": "Convert linked filenames to lower case.",
+            "type": "boolean",
+            "default": true,
+        },
+        {
+            "identifier": "wikilinksReplaceSpacesSymbol",
+            "name": "Wiki Links Replace Spaces Symbol",
+            "description": "If Wiki links Remove Spaces option is selected, the symbol to replace spaces in filenames with (default: dash, replace with blank to remove spaces without replacing)",
+            "type": "string",
+            "default": "-",
+        },
+        {
+            "identifier": "wikilinksHideSubfolder",
+            "name": "Wiki Links Hide Subfolder",
+            "description": "Hide the subfolder name in link text",
+            "type": "boolean",
+            "default": true,
+        },
+        {
+            "identifier": "wikilinksBackgroundColor",
+            "name": "Wiki Links Background Color",
+            "description": "Color for the backgroud of rendered wiki links (name or #hex):",
+            "type": "string",
+            "default": "#FFFF00",
+        },
+        {
+            "identifier": "wikilinksForegroundColor",
+            "name": "Wiki Links Foreground Color",
+            "description": "Color for the foreground of rendered wiki links (name or #hex):",
+            "type": "string",
+            "default": "#ff832b",
+        }
+    ];
+    /**
+     * This function is called when the markdown html of a note is generated
+     *
+     * It allows you to modify this html
+     * This is for example called before by the note preview
+     *
+     * The method can be used in multiple scripts to modify the html of the preview
+     *
+     * @param {NoteApi} note - the note object
+     * @param {string} html - the html that is about to being rendered
+     * @param {string} forExport - the html is used for an export, false for the preview
+     * @return {string} the modified html or an empty string if nothing should be modified
+     */
+
+    function getFilePath(path) {
+        if (script.platformIsWindows()) {
+            path = "/" + path;
+        }
+
+        var filePath = "file://" + path + "/";
+        return filePath;
+    }
+
+    function getSubfolder(note, path) {
+        var fileName = note.fullNoteFilePath;
+        var pathRe = new RegExp(path + "\/(.*\/)*.*");
+        var subfolderName = fileName.replace(pathRe, "$1");
+        return subfolderName;
+    }
+
+    function formatLink(unescapedTitle, linkTitle, filePath, subfolderName) {
+        var escapedTitle = unescapedTitle;
+        var prettyTitle = linkTitle;
+        if (wikilinksSanitizeFilename) {
+            escapedTitle = escapedTitle.replace(/[\!\?\.,\(\)\[\]@\$\^\&\*"';:<>]/g, "");
+        }
+        if (wikilinksRemoveSpaces) {
+            escapedTitle = escapedTitle.replace(/\s+/g, wikilinksReplaceSpacesSymbol);
+        }
+        if (wikilinksLowerCase) {
+            escapedTitle = escapedTitle.toLowerCase();
+        }
+        if (wikilinksHideSubfolder) {
+            prettyTitle = prettyTitle.replace(/.*\//, "");
+        }
+
+        if (!/\//.test(escapedTitle)) {
+            escapedTitle = subfolderName + escapedTitle.replace(/.*\//, "");
+        }
+
+        var formattedLink = "<a href=\"" + filePath + escapedTitle + ".md\">" + prettyTitle + "</a>";
+        return formattedLink;
+    }
+
+    function noteToMarkdownHtmlHook(note, html, forExport) {
+        var path = script.currentNoteFolderPath();
+        var subfolderName = getSubfolder(note, path);
+        var filePath = getFilePath(path);
+
+        html = html.replace(new RegExp("<x-wikilink data-target=\"(.*?)\">(.*?)</x-wikilink>", "gi"), function(_, unescapedTitle, linkTitle) {
+            return formatLink(unescapedTitle, linkTitle, filePath, subfolderName);
+        });
+        return html;
+    }
+}


### PR DESCRIPTION
This script adds support for wiki-style internal links (for example `[[link]]`). Details can be found on the [wiki page](https://dohliam.github.io/qownnotes-scripting/scripts/wiki-links.html) for the script. There are a couple of other scripts that depend on this one (namely [backlinks](https://dohliam.github.io/qownnotes-scripting/scripts/backlinks.html) and [exporting note collections as a website](https://dohliam.github.io/qownnotes-scripting/scripts/export-notes-as-website.html)). These will be added in a subsequent PR!