### PR TITLE
Add blank note script

### DIFF
--- a/blank-note/blank-note.qml
+++ b/blank-note/blank-note.qml
@@ -1,0 +1,50 @@
+import QtQml 2.0
+import QOwnNotesTypes 1.0
+
+/**
+ * This script creates a custom action to create a new blank note with no headline or other text.
+ */
+QtObject {
+    /**
+     * Initializes the custom action
+     */
+    function init() {
+        script.registerCustomAction("blankNote", "Create a new blank note", "Blank note", "document-new");
+    }
+
+    /**
+     * This function is invoked when a custom action is triggered
+     * in the menu or via button
+     *
+     * @param identifier string the identifier defined in registerCustomAction
+     */
+
+    function getSubfolder() {
+        var noteSubFolderQmlObj = Qt.createQmlObject("import QOwnNotesTypes 1.0; NoteSubFolder{}", mainWindow, "noteSubFolder");
+        var subFolder = noteSubFolderQmlObj.activeNoteSubFolder();
+        return subFolder.fullPath();
+    }
+
+    function customActionInvoked(identifier) {
+        if (identifier != "blankNote") {
+            return;
+        }
+
+        var headline = script.inputDialogGetText(
+            "line edit", "Note title", "");
+
+        var text = "";
+        var subFolder = getSubfolder();
+        var filePath = subFolder + script.dirSeparator();
+        var fileName = headline + ".md";
+        script.writeToFile(filePath + fileName, text);
+
+        // Force a reload of the note list
+        mainWindow.buildNotesIndexAndLoadNoteDirectoryList(true, true);
+
+        var note = script.fetchNoteByFileName(fileName);
+        script.setCurrentNote(note);
+        script.log("New blank note created: " + filePath + fileName);
+    }
+
+}

--- a/blank-note/info.json
+++ b/blank-note/info.json
@@ -1,0 +1,10 @@
+{
+  "name": "Blank Note",
+  "identifier": "blank-note",
+  "script": "blank-note.qml",
+  "authors": ["@dohliam"],
+  "platforms": ["linux", "macos", "windows"],
+  "version": "0.0.1",
+  "minAppVersion": "20.6.0",
+  "description" : "Create a new blank note with no headline or other text."
+}

--- a/blank-note/info.json
+++ b/blank-note/info.json
@@ -5,6 +5,6 @@
   "authors": ["@dohliam"],
   "platforms": ["linux", "macos", "windows"],
   "version": "0.0.1",
-  "minAppVersion": "20.6.0",
+  "minAppVersion": "22.2.6",
   "description" : "Create a new blank note with no headline or other text."
 }


### PR DESCRIPTION
- Add blank note script to allow creating new notes with no content
- Fixes [this issue](https://github.com/pbek/QOwnNotes/issues/2411)
- Thanks @pbek for the help with `NoteSubFolderApi`!