### PR TITLE
Add definition lists script

### DIFF
--- a/definition-lists/definition-lists.qml
+++ b/definition-lists/definition-lists.qml
@@ -1,0 +1,25 @@
+import QtQml 2.0
+import QOwnNotesTypes 1.0
+
+QtObject {
+    /**
+     * This function is called when the markdown html of a note is generated
+     *
+     * It allows you to modify this html
+     * This is for example called before by the note preview
+     *
+     * The method can be used in multiple scripts to modify the html of the preview
+     *
+     * @param {NoteApi} note - the note object
+     * @param {string} html - the html that is about to being rendered
+     * @param {string} forExport - the html is used for an export, false for the preview
+     * @return {string} the modified html or an empty string if nothing should be modified
+     */
+
+    function noteToMarkdownHtmlHook(note, html, forExport) {
+        html = html.replace(/<\/style>/, "dt {font-weight: bold; font-style: italic;}</style>");
+        var re = new RegExp("<p>(.*?)\n: (.*?)</p>", "g");
+        html = html.replace(re, "<dl>\n  <dt>$1</dt>\n  <dd>$2</dd>\n</dl>");
+        return html;
+    }
+}

--- a/definition-lists/info.json
+++ b/definition-lists/info.json
@@ -1,0 +1,10 @@
+{
+  "name": "Definition lists",
+  "identifier": "definition-lists",
+  "script": "definition-lists.qml",
+  "authors": ["@dohliam"],
+  "platforms": ["linux", "macos", "windows"],
+  "version": "0.0.1",
+  "minAppVersion": "20.6.0",
+  "description" : "Add support for definition lists."
+}


### PR DESCRIPTION
This script adds basic support for definition lists (as per request in [#2100](https://github.com/pbek/QOwnNotes/issues/2100)).

Future additions could include: support for allowing the user to configure the style of the description term (`<dt>`) and description details (`<dd>`) elements, and perhaps using the new syntax highlighting scripting feature to highlight the text in the editor window.

Also, this currently converts multiple definitions into separate lists -- this should eventually be fixed to make multiple definitions part of the same list. However, it should still be usable as is.