### PR TITLE
Fix definition lists script to allow for multiple definitions in a list

### DIFF
--- a/definition-lists/definition-lists.qml
+++ b/definition-lists/definition-lists.qml
@@ -18,8 +18,25 @@ QtObject {
 
     function noteToMarkdownHtmlHook(note, html, forExport) {
         html = html.replace(/<\/style>/, "dt {font-weight: bold; font-style: italic;}</style>");
-        var re = new RegExp("<p>(.*?)\n: (.*?)</p>", "g");
-        html = html.replace(re, "<dl>\n  <dt>$1</dt>\n  <dd>$2</dd>\n</dl>");
+        var re = new RegExp("<p>(.*?\n: [^]*?)</p>", "g");
+        if (re.test(html)) {
+            html = html.replace(re, function(_, dl) {
+                var output = "<dl>\n"
+                var dlArray = dl.split("\n");
+                for (var i = 0; i < dlArray.length; i++) {
+                    var item = dlArray[i];
+                    var entryText = "  <dt>" + item + "</dt>\n";
+                    if (item.match(/^: /)) {
+                        var defText = item.replace(/^: /g, "")
+                        entryText = "  <dd>" + defText + "</dd>\n";
+                    }
+                    output += entryText;
+                }
+                output += "</dl>";
+                script.log(output);
+                return output;
+            });
+        }
         return html;
     }
 }

--- a/definition-lists/info.json
+++ b/definition-lists/info.json
@@ -4,7 +4,7 @@
   "script": "definition-lists.qml",
   "authors": ["@dohliam"],
   "platforms": ["linux", "macos", "windows"],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "minAppVersion": "20.6.0",
   "description" : "Add support for definition lists."
 }


### PR DESCRIPTION
The previous version only worked with a single definition. This version allows for multiple definitions, in the form:

```
Term 1
: Definition 1
Term 2
: Definition 2
Term 3
: Definition 3
etc
```