### PR TITLE
Add link titles script

### DIFF
--- a/link-titles/info.json
+++ b/link-titles/info.json
@@ -6,5 +6,5 @@
   "platforms": ["linux", "macos", "windows"],
   "version": "0.0.1",
   "minAppVersion": "20.6.0",
-  "description" : "Add titles / pop-ups to links showing their target location."
+  "description" : "Add titles / pop-ups to links in the preview, showing their target location."
 }

--- a/link-titles/info.json
+++ b/link-titles/info.json
@@ -1,0 +1,10 @@
+{
+  "name": "Link titles",
+  "identifier": "link-titles",
+  "script": "link-titles.qml",
+  "authors": ["@dohliam"],
+  "platforms": ["linux", "macos", "windows"],
+  "version": "0.0.1",
+  "minAppVersion": "20.6.0",
+  "description" : "Add titles / pop-ups to links showing their target location."
+}

--- a/link-titles/link-titles.qml
+++ b/link-titles/link-titles.qml
@@ -1,0 +1,24 @@
+import QtQml 2.0
+import QOwnNotesTypes 1.0
+
+QtObject {
+    /**
+     * This function is called when the markdown html of a note is generated
+     *
+     * It allows you to modify this html
+     * This is for example called before by the note preview
+     *
+     * The method can be used in multiple scripts to modify the html of the preview
+     *
+     * @param {NoteApi} note - the note object
+     * @param {string} html - the html that is about to being rendered
+     * @param {string} forExport - the html is used for an export, false for the preview
+     * @return {string} the modified html or an empty string if nothing should be modified
+     */
+
+    function noteToMarkdownHtmlHook(note, html, forExport) {
+        var re = new RegExp('<a href="([^"]+)">', 'g');
+        html = html.replace(re, "<a href=\"$1\" title=\"$1\">");
+        return html;
+    }
+}


### PR DESCRIPTION
This script adds title text to all links. The title text displays the link target. This can be helpful in the following situations:

* If you have a lot of links that are automatically generated by a script
* If you are using local links (e.g., with the `wiki-links` script)
* If there are many links and other elements on the page and the preview is not synchronized with the editor window, making it difficult to find the full link in the markdown text
* Possibly others...