### PR TITLE
Add toggle comment script

### DIFF
--- a/toggle-comment/info.json
+++ b/toggle-comment/info.json
@@ -1,0 +1,9 @@
+{
+  "name": "Toggle comment",
+  "identifier": "toggle-comment",
+  "script": "toggle-comment.qml",
+  "authors": ["@dohliam"],
+  "version": "1.0",
+  "minAppVersion": "20.4.16",
+  "description" : "This script creates a custom action to comment/uncomment the current Markdown line."
+}

--- a/toggle-comment/toggle-comment.qml
+++ b/toggle-comment/toggle-comment.qml
@@ -1,0 +1,44 @@
+import QtQml 2.0
+import com.qownnotes.noteapi 1.0
+
+/**
+ * This script creates a custom action to comment or uncomment the current Markdown line
+ */
+QtObject {
+    /**
+     * Initializes the custom action
+     */
+    function init() {
+        script.registerCustomAction("toggle-comment", "Comment/uncomment the current line", "Comment/uncomment", "edit-comment");
+    }
+
+    function setComment(line) {
+        var commented = line.replace(/^(.*)$/, "[//]: # ($1)");
+        return commented;
+    }
+
+    function unsetComment(line) {
+        var uncommented = line.replace(/^\[\/\/\]: # \((.*)\)$/, "$1");
+        return uncommented;
+    }
+
+    /**
+     * This function is invoked when a custom action is triggered
+     * in the menu or via button
+     *
+     * @param identifier string the identifier defined in registerCustomAction
+     */
+    function customActionInvoked(identifier) {
+        if (identifier != "toggle-comment") {
+            return;
+        }
+
+        script.noteTextEditSelectCurrentLine();
+        var line = script.noteTextEditSelectedText();
+        if (/^\[\/\/\]: #/.test(line)) {
+            script.noteTextEditWrite(unsetComment(line));
+        } else {
+            script.noteTextEditWrite(setComment(line));
+        }
+    }
+}


### PR DESCRIPTION
This script adds an action to allow commenting or uncommenting  the current line of markdown text in the edit window.