### PR TITLE
Add italicize script

### DIFF
--- a/italicize/info.json
+++ b/italicize/info.json
@@ -1,0 +1,9 @@
+{
+  "name": "Italicize",
+  "identifier": "italicize",
+  "script": "italicize.qml",
+  "authors": ["@dohliam"],
+  "version": "1.0",
+  "minAppVersion": "20.4.16",
+  "description" : "This script creates a custom action to italicize selected text using single underscores (e.g.: _this is italic text_)."
+}

--- a/italicize/italicize.qml
+++ b/italicize/italicize.qml
@@ -1,0 +1,36 @@
+import QtQml 2.0
+import com.qownnotes.noteapi 1.0
+
+/**
+ * This script creates a custom action to italicize selected text using single underscores
+ */
+QtObject {
+    /**
+     * Initializes the custom action
+     */
+    function init() {
+        script.registerCustomAction("italicize", "Italicize selected text using underscores", "Italicize text", "format-text-italic");
+    }
+
+    function addItalics(text) {
+        var italics = text.replace(/^(.*)$/, "_$1_");
+        return italics;
+    }
+
+    /**
+     * This function is invoked when a custom action is triggered
+     * in the menu or via button
+     *
+     * @param identifier string the identifier defined in registerCustomAction
+     */
+    function customActionInvoked(identifier) {
+        if (identifier != "italicize") {
+            return;
+        }
+
+        // get the selected text from the note text edit
+        var text = script.noteTextEditSelectedText();
+        // write text to the note text edit
+        script.noteTextEditWrite(addItalics(text));
+    }
+}


### PR DESCRIPTION
Since there is no existing option to change the use of single asterisks for emphasis/italic text by default in QOwnNotes, this script adds an action that italicizes selected text using single underscores instead (for example: `_italic text_`). Those that prefer to use single underscores can then change the shortcut and toolbar icon to use this custom action instead if they wish.