### PR TITLE
0.0.2 of autodetect-text-direction

### DIFF
--- a/autodetect-text-direction/autodetect-text-direction.qml
+++ b/autodetect-text-direction/autodetect-text-direction.qml
@@ -1,6 +1,6 @@
 import QtQml 2.0
 
-Script {
+QtObject {
 
     /**
      * adds 'dir="rtl"' to content tags whose first character with a strong direction is RTL.

--- a/autodetect-text-direction/info.json
+++ b/autodetect-text-direction/info.json
@@ -4,7 +4,7 @@
   "script": "autodetect-text-direction.qml",
   "authors": ["@noureddin"],
   "platforms": ["linux", "macos", "windows"],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "minAppVersion": "22.11.7",
-  "description" : "Automatically make any heading, paragraph, list item, or table cell that starts with an Arabic (or any right-to-left) letter renders with the correct text direction."
+  "description" : "Automatically make any heading, paragraph, list item, or table cell that starts with an Arabic (or any right-to-left) letter render with the correct text direction."
 }


### PR DESCRIPTION
The [scripts repo's README](https://github.com/qownnotes/scripts) instructs scripts authors to build on the `example-script/` which uses `Script` as the root object of the script. Apparently this doesn't work at all, with no log, and logs an error when loaded locally. Changing it to `QtObject` fixes it.