### PR TITLE
Adding highlight in the editor

### DIFF
--- a/text-highlights/info.json
+++ b/text-highlights/info.json
@@ -2,9 +2,9 @@
   "name": "Text Highlights",
   "identifier": "text-highlights",
   "script": "text-highlights.qml",
-  "authors": ["@mleo2003", "@ryliejamesthomas"],
+  "authors": ["@mleo2003", "@ryliejamesthomas", "@Beurt"],
   "platforms": ["linux", "macos", "windows"],
-  "version": "0.0.4",
-  "minAppVersion": "20.6.0",
-  "description" : "Provide a way to highlight text in markdown and render it as some other markdown viewers do. Uses ==text== syntax, and the color shown is configurable."
+  "version": "0.0.5",
+  "minAppVersion": "22.4.1",
+  "description" : "Provide a way to highlight text in markdown and render it as some other markdown viewers do. Uses ==text== syntax, and the color shown in the preview, and the style in the editor are configurable."
 }

--- a/text-highlights/text-highlights.qml
+++ b/text-highlights/text-highlights.qml
@@ -3,6 +3,8 @@ import QOwnNotesTypes 1.0
 
 QtObject {
 	property string backgroundColor;
+	property string styleInEditor;
+	property string styleForEditor;
 
 	property variant settingsVariables: [
 		{
@@ -11,6 +13,50 @@ QtObject {
 			"description": "Color to highlight text with (name or #hex):",
 			"type": "string",
 			"default": "#FFFF00",
+		},
+		{
+			"identifier": "styleInEditor",
+			"name": "Highlight in editor panel",
+			"description": "Do you want to highlight the text also in the editor panel?",
+			"text": "Highlight text in the editor",
+			"type": "boolean",
+			"default": false,
+		},
+		{
+			"identifier": "styleForEditor",
+			"name": "Higlight style for the editor",
+			"description": "Please select a style for the highlight in the editor (available only if the previous option is checked)",
+			"type": "selection",
+			"default": "8",
+			"items": {
+					"-1": "NoState",
+					"0": "Link",
+					"3": "Image",
+					"4": "CodeBlock",
+					"5": "CodeBlockComment",
+					"7": "Italic",
+					"8": "Bold",
+					"9": "List",
+					"11": "Comment",
+					"12": "H1",
+					"13": "H2",
+					"14": "H3",
+					"15": "H4",
+					"16": "H5",
+					"17": "H6",
+					"18": "BlockQuote",
+					"21": "HorizontalRuler",
+					"22": "Table",
+					"23": "InlineCodeBlock",
+					"24": "MaskedSyntax",
+					"25": "CurrentLineBackgroundColor",
+					"26": "BrokenLink",
+					"27": "FrontmatterBlock",
+					"28": "TrailingSpace",
+					"29": "CheckBoxUnChecked",
+					"30": "CheckBoxChecked",
+					"31": "StUnderline"
+			},
 		}
 	];
     
@@ -36,6 +82,11 @@ QtObject {
 
 	function init() {
 		script.registerCustomAction("addHighlights", "Add Highlight Marks", "Add Highlights", "text-wrap");
+		if (styleInEditor) {
+			script.addHighlightingRule("(==)([^=]*)?==", "", 24, 1, -1);
+			script.addHighlightingRule("==([^=]*)?(==)", "", 24, 2, -1);
+			script.addHighlightingRule("==([^=]*)?==", "", parseInt(styleForEditor), 1, -1);
+		}
 	}
 
 	function customActionInvoked(identifier) {


### PR DESCRIPTION
cf. https://github.com/qownnotes/scripts/issues/165

It is not activated by default
You can select the style for the highlight in the editor