### PR TITLE
Two new scripts to hightlight things in the editor panel

### DIFF
--- a/characters-highlight/characters-highlight.qml
+++ b/characters-highlight/characters-highlight.qml
@@ -1,0 +1,58 @@
+import QtQml 2.0
+import QOwnNotesTypes 1.0
+
+QtObject {
+	property string styleForEditor;
+	property string charactersList;
+    property var qownStyles: {
+					"-1": "NoState",
+					"0": "Link",
+					"3": "Image",
+					"4": "CodeBlock",
+					"5": "CodeBlockComment",
+					"7": "Italic",
+					"8": "Bold",
+					"9": "List",
+					"11": "Comment",
+					"12": "H1",
+					"13": "H2",
+					"14": "H3",
+					"15": "H4",
+					"16": "H5",
+					"17": "H6",
+					"18": "BlockQuote",
+					"21": "HorizontalRuler",
+					"22": "Table",
+					"23": "InlineCodeBlock",
+					"24": "MaskedSyntax",
+					"25": "CurrentLineBackgroundColor",
+					"26": "BrokenLink",
+					"27": "FrontmatterBlock",
+					"28": "TrailingSpace",
+					"29": "CheckBoxUnChecked",
+					"30": "CheckBoxChecked",
+					"31": "StUnderline"
+			};
+
+	property var settingsVariables: [
+		{
+			"identifier": "charactersList",
+			"name": "List of charachters to highlight",
+			"description": "Please list all the characters you want to highlight (without ANY separation, such as coma or spaces). Warning, by default the sting is NOT EMPTY but contains two different bearking spaces to highlight (U+00A0 and U+202F).",
+			"type": "string",
+			"default": "  ",
+		},
+		{
+			"identifier": "styleForEditor",
+			"name": "Highlight style for the choosen charchacters",
+			"description": "Please select a style for the characters highlight",
+			"type": "selection",
+			"default": "28",
+			"items": qownStyles
+			}
+	];
+
+    function init() {
+        script.addHighlightingRule("[" + charactersList + "]", "", parseInt(styleForEditor));
+    }
+} 

--- a/characters-highlight/info.json
+++ b/characters-highlight/info.json
@@ -1,0 +1,10 @@
+{
+  "name": "Highlight specific characters in the editor",
+  "identifier": "characters-highlights",
+  "script": "characters-highlights.qml",
+  "authors": ["@Beurt"],
+  "platforms": ["linux", "macos", "windows"],
+  "version": "0.0.1",
+  "minAppVersion": "22.4.1",
+  "description" : "The script was meant to highlight in the editor the non breaking spaces. But, as you can set the characters to highlight (and their style), you may be able to highlight everything you want."
+}

--- a/characters-highlight/info.json
+++ b/characters-highlight/info.json
@@ -1,7 +1,7 @@
 {
   "name": "Highlight specific characters in the editor",
-  "identifier": "characters-highlights",
-  "script": "characters-highlights.qml",
+  "identifier": "characters-highlight",
+  "script": "characters-highlight.qml",
   "authors": ["@Beurt"],
   "platforms": ["linux", "macos", "windows"],
   "version": "0.0.1",

--- a/html-highlight/html-highlight.qml
+++ b/html-highlight/html-highlight.qml
@@ -1,0 +1,82 @@
+import QtQml 2.0
+import QOwnNotesTypes 1.0
+
+QtObject {
+	property string styleForMainColor;
+	property string styleForTagName;
+	property string styleForAttrName;
+	property string styleForAttr;
+    property var qownStyles: {
+					"-1": "NoState",
+					"0": "Link",
+					"3": "Image",
+					"4": "CodeBlock",
+					"5": "CodeBlockComment",
+					"7": "Italic",
+					"8": "Bold",
+					"9": "List",
+					"11": "Comment",
+					"12": "H1",
+					"13": "H2",
+					"14": "H3",
+					"15": "H4",
+					"16": "H5",
+					"17": "H6",
+					"18": "BlockQuote",
+					"21": "HorizontalRuler",
+					"22": "Table",
+					"23": "InlineCodeBlock",
+					"24": "MaskedSyntax",
+					"25": "CurrentLineBackgroundColor",
+					"26": "BrokenLink",
+					"27": "FrontmatterBlock",
+					"28": "TrailingSpace",
+					"29": "CheckBoxUnChecked",
+					"30": "CheckBoxChecked",
+					"31": "StUnderline"
+			};
+
+	property var settingsVariables: [
+		{
+			"identifier": "styleForMainColor",
+			"name": "Main highlight style for HTML tags",
+			"description": "Please select a style for the main highlight of HTML tags",
+			"type": "selection",
+			"default": "3",
+			"items": qownStyles
+			},
+		{
+			"identifier": "styleForTagName",
+			"name": "Highlight style for HTML tags names",
+			"description": "Please select a style for the highlight for the HTML tags names",
+			"type": "selection",
+			"default": "11",
+			"items": qownStyles
+		},
+		{
+			"identifier": "styleForAttrName",
+			"name": "Highlight style for HTML attributes names",
+			"description": "Please select a style for the highlight for the HTML attributes names",
+			"type": "selection",
+			"default": "7",
+			"items": qownStyles
+		},
+		{
+			"identifier": "styleForAttr",
+			"name": "Highlight style for HTML attributes values",
+			"description": "Please select a style for the highlight for the HTML attributes values",
+			"type": "selection",
+			"default": "11",
+			"items": qownStyles
+		}
+	];
+        
+
+    function init() {
+        script.addHighlightingRule("<(\\S*?)[^>]>.?<\\1>|<.*?>", "", parseInt(styleForMainColor));
+        script.addHighlightingRule("<(\\S*?)[^>]>.?<\\1>|<.*?>", "", parseInt(styleForTagName), 1, -1);
+        script.addHighlightingRule("<(\\S*?)[^>]>.?<\\1>|<(.*?)>", "", parseInt(styleForTagName), 2, -1);
+        script.addHighlightingRule("(\\w+)=[\"']?((?:.(?![\"']?\\s+(?:\\S+)=|\\s*\/?[>\"']))+.)[\"']?", "", parseInt(styleForAttrName), 1, -1);
+        script.addHighlightingRule("(\\w+)=[\"']?((?:.(?![\"']?\\s+(?:\\S+)=|\\s*\/?[>\"']))+.)[\"']?", "", parseInt(styleForAttr), 2, -1);
+    }
+} 

--- a/html-highlight/html-highlight.qml
+++ b/html-highlight/html-highlight.qml
@@ -47,24 +47,24 @@ QtObject {
 			},
 		{
 			"identifier": "styleForTagName",
-			"name": "Highlight style for HTML tags names",
-			"description": "Please select a style for the highlight for the HTML tags names",
+			"name": "Highlight style for HTML tag names",
+			"description": "Please select a style for the highlight for the HTML tag names",
 			"type": "selection",
 			"default": "11",
 			"items": qownStyles
 		},
 		{
 			"identifier": "styleForAttrName",
-			"name": "Highlight style for HTML attributes names",
-			"description": "Please select a style for the highlight for the HTML attributes names",
+			"name": "Highlight style for HTML attribute names",
+			"description": "Please select a style for the highlight for the HTML attribute names",
 			"type": "selection",
 			"default": "7",
 			"items": qownStyles
 		},
 		{
 			"identifier": "styleForAttr",
-			"name": "Highlight style for HTML attributes values",
-			"description": "Please select a style for the highlight for the HTML attributes values",
+			"name": "Highlight style for HTML attribute values",
+			"description": "Please select a style for the highlight for the HTML attribute values",
 			"type": "selection",
 			"default": "11",
 			"items": qownStyles

--- a/html-highlight/info.json
+++ b/html-highlight/info.json
@@ -1,7 +1,7 @@
 {
   "name": "HTML Highlights",
-  "identifier": "html-highlights",
-  "script": "html-highlights.qml",
+  "identifier": "html-highlight",
+  "script": "html-highlight.qml",
   "authors": ["@Beurt"],
   "platforms": ["linux", "macos", "windows"],
   "version": "0.0.1",

--- a/html-highlight/info.json
+++ b/html-highlight/info.json
@@ -6,5 +6,5 @@
   "platforms": ["linux", "macos", "windows"],
   "version": "0.0.1",
   "minAppVersion": "22.4.1",
-  "description" : "If your are, sometimes, using plan HTML in your markdown, and want to see it highlighted in your editor, this script is for you. You will be able to configure the style for the whole HTML tags, the tags names, the attributes names, and the attributes values."
+  "description" : "If you are, sometimes, using plain HTML in your markdown, and want to see it highlighted in your editor, this script is for you. You will be able to configure the style for the whole HTML tags, the tag names, the attribute names, and the attribute values."
 }

--- a/html-highlight/info.json
+++ b/html-highlight/info.json
@@ -1,0 +1,10 @@
+{
+  "name": "HTML Highlights",
+  "identifier": "html-highlights",
+  "script": "html-highlights.qml",
+  "authors": ["@Beurt"],
+  "platforms": ["linux", "macos", "windows"],
+  "version": "0.0.1",
+  "minAppVersion": "22.4.1",
+  "description" : "If your are, sometimes, using plan HTML in your markdown, and want to see it highlighted in your editor, this script is for you. You will be able to configure the style for the whole HTML tags, the tags names, the attributes names, and the attributes values."
+}


### PR DESCRIPTION
- one for highlighting HTML in the markdown
- another to highlight specific characters (default: non breaking spaces)

For both, users can set the style(s). 