### PR TITLE
Improve order checkboxes script

### DIFF
--- a/order-checkboxes/info.json
+++ b/order-checkboxes/info.json
@@ -2,7 +2,7 @@
   "name": "Order checkboxes",
   "identifier": "order-checkboxes",
   "script": "order-checkboxes.qml",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "minAppVersion": "19.3.2",
   "authors": ["@sanderboom"],
   "description" : "This script creates a menu item and a button to order checkboxes. Selected lines containing checkboxes will be ordered as follows: <code>[x]</code> checked -> <code>[-]</code> disabled -> <code>[ ]</code> unchecked. Pro tip: assign a shortcut.<br><br>Note: currently only works with <code>tab</code> as indentation character."

--- a/order-checkboxes/order-checkboxes.qml
+++ b/order-checkboxes/order-checkboxes.qml
@@ -2,7 +2,6 @@ import QtQml 2.0
 import com.qownnotes.noteapi 1.0
 
 // TODO:
-// - make work with \r\n as well as \n
 // - make the order configurable
 // - add more checkbox types
 
@@ -18,6 +17,7 @@ QtObject {
     property bool qonSettingEditorUseTabIndent;
     property int qonSettingEditorIndentSize;
     property string singleIndentation;
+    property string lineEnding;
 
     property variant settingsVariables: [
         {
@@ -49,6 +49,13 @@ QtObject {
             false, /* hideButtonInToolbar */
             false /* useInNoteListContextMenu */
         );
+
+        // Determine line ending.
+        if (script.platformIsWindows() && !script.getApplicationSettingsVariable("useUNIXNewline")) {
+            lineEnding = '\r\n';
+        } else {
+            lineEnding = '\n';
+        }
 
         // Get the indentation setting.
         qonSettingEditorUseTabIndent = script.getApplicationSettingsVariable("Editor/useTabIndent");
@@ -94,7 +101,7 @@ QtObject {
 
         // Text -> structured.
         let structured = [];
-        const rows = input.split('\n').filter((row) => row.trim() !== '');
+        const rows = input.split(lineEnding).filter((row) => row.trim() !== '');
         if (rows.length < 1) return;
 
         // Support ordering just sublevel checkbox lists.
@@ -180,7 +187,7 @@ QtObject {
         function unfold(out, prefix) {
             out.forEach((item) => {
                 // Create output text by adding toplevelIndentation and the level of indentation needed for this level.
-                text_sorted = text_sorted + toplevelIndentation + prefix + item.txt + '\n';
+                text_sorted = text_sorted + toplevelIndentation + prefix + item.txt + lineEnding;
 
                 // In case of a sublevel, add indent and recurse.
                 if (item.hasOwnProperty('sub')) {

--- a/order-checkboxes/order-checkboxes.qml
+++ b/order-checkboxes/order-checkboxes.qml
@@ -3,9 +3,8 @@ import com.qownnotes.noteapi 1.0
 
 // TODO:
 // - make it work without the need to start with a toplevel element
-// - make it work with different types of indentation styles (spaces)
 // - make the order configurable
-// - add more checkbox tyes
+// - add more checkbox types
 
 /**
  * This script creates a menu item and a button to order checkboxes.
@@ -16,6 +15,9 @@ import com.qownnotes.noteapi 1.0
 QtObject {
     property bool reverseOrder;
     property bool keepSelection;
+    property bool qonSettingEditorUseTabIndent;
+    property int qonSettingEditorIndentSize;
+    property string singleIndentation;
 
     property variant settingsVariables: [
         {
@@ -47,6 +49,21 @@ QtObject {
             false, /* hideButtonInToolbar */
             false /* useInNoteListContextMenu */
         );
+
+        // Get the indentation setting.
+        qonSettingEditorUseTabIndent = script.getApplicationSettingsVariable("Editor/useTabIndent");
+        qonSettingEditorIndentSize = script.getApplicationSettingsVariable("Editor/indentSize");
+
+        // Determine the single indentation char(s).
+        if (qonSettingEditorUseTabIndent) {
+            singleIndentation = '\t';
+        } else {
+            singleIndentation = ' '.repeat(qonSettingEditorIndentSize);
+        }
+
+        script.log('order-checkboxes.init() qonSettingEditorUseTabIndent: ' + qonSettingEditorUseTabIndent);
+        script.log('order-checkboxes.init() qonSettingEditorIndentSize: ' + qonSettingEditorIndentSize);
+        script.log('order-checkboxes.init() singleIndentation.length: ' + singleIndentation.length.toString());
     }
 
     /**
@@ -111,12 +128,12 @@ QtObject {
                 }
 
                 // Remove the first indentation and recurse.
-                row = row.replace('\t', '');
+                row = row.replace(singleIndentation, '');
                 addItemToLevel(last(level).sub, row);
             }
 
             function isTopLevel(row) {
-                return !(row.startsWith(' ') || row.startsWith('\t'));
+                return !row.startsWith(singleIndentation);
             }
 
             function last(level) {
@@ -160,7 +177,7 @@ QtObject {
                 text_sorted = text_sorted + prefix + item.txt + '\n';
                 // In case of a sublevel, add indent and recurse.
                 if (item.hasOwnProperty('sub')) {
-                    unfold(item.sub, prefix + '\t');
+                    unfold(item.sub, prefix + singleIndentation);
                 }
             });
         }


### PR DESCRIPTION
Improves order checkboxes script: 
- to respect user-setting indentation type (tabs/spaces, number of spaces)
- to support ordering just sublevel checkbox lists
- to also support Windows line ending (\r\n)

