### PR TITLE
extract-todos v1.1

### DIFF
--- a/extract-todos/extract-todos.qml
+++ b/extract-todos/extract-todos.qml
@@ -3,14 +3,22 @@ import QOwnNotesTypes 1.0
 
 Script {
     property string subFolder;
+    property string headerText;
     property variant settingsVariables: [
         {
-			"identifier": "subFolder",
-			"name": "TODO Subfolder",
-			"description": "Restrict search for TODOs to this note subfolder.",
-			"type": "string",
-			"default": "",
-		}
+            "identifier": "subFolder",
+            "name": "TODO Subfolder",
+            "description": "Restrict search for TODOs to this note subfolder.",
+            "type": "string",
+            "default": "",
+        },
+        {
+            "identifier": "headerText",
+            "name": "Header Text",
+            "description": "Header text for your TODO listing",
+            "type": "string",
+            "default": "Open TODOs",
+        }
     ];
     
     function init() {
@@ -19,13 +27,11 @@ Script {
     }
     
     function extractTodos() {
-
         const path = script.currentNoteFolderPath() + "/" + subFolder;
         const findResult = script.startSynchronousProcess("find", ["\(", "-name", "*.md", "-or", "-name", "*.txt", "\)", "-printf", "%P\n"], "", path);
-        const files = findResult.toString().split("\n");
- 
+        const files = findResult.toString().split("\n"); 
         const todoRegex = /^\s*- \[ \]\s*/;
-        var output = "<h1>Open TODOs</h1>\n";
+        var output = "<h1>" + headerText + "</h1>";
 
         for (const i in files) {
             const file = files[i];
@@ -35,15 +41,20 @@ Script {
                             .filter(s => s.match(todoRegex))
                             .map(s => s.replace(todoRegex, ""));
             if (todos.length > 0) {
-                output +=  "<h3>" + file + "</h3><ul>\n";
+                output +=  "<h3>" + getBaseName(file) + "</h3><ul>";
                 for (const j in todos) {
-                    output += "<p>" + todos[j] + "</p>\n";
+                    output += "<p>" + todos[j] + "</p>";
                 }
-                output += "</ul>\n";
+                output += "</ul>";
             }
         }
-
         script.setLabelText("extract todos", output);
+    }
+
+    function getBaseName(path) {
+        const fileName = path.slice(path.lastIndexOf("/") + 1);
+        const baseName = fileName.slice(0, fileName.indexOf("."));
+	return baseName;
     }
 
     function onNoteStored(note) { extractTodos() }

--- a/extract-todos/info.json
+++ b/extract-todos/info.json
@@ -4,8 +4,8 @@
   "script": "extract-todos.qml",
   "authors": ["@jaschop-1k5o"],
   "platforms": ["linux"],
-  "version": "1.0",
+  "version": "1.1",
   "minAppVersion": "24.5.1",
-  "description" : "Continuously scan your note folder for open TODOs, and display them in the scripting panel.\n\nTODOs are identified according to Markdown syntax, by lines starting with `- [ ]`\nScanning can be restricted to a subfolder.\n(Note: Script uses `find` and `grep` in the background.)"
+  "description" : "Continuously scan your note folder for open TODOs, and display them in the scripting panel.\n\nTODOs are identified according to Markdown syntax, by lines starting with `- [ ]`\nScanning can be restricted to a subfolder.\n(Note: Script uses `find` and `cat` in the background.)"
 }
 


### PR DESCRIPTION
- Directories and file extensions are now filtered from the TODO listing. (Works for UNIX path syntax, couldn't figure out how to import a proper path library.)
- TODO listing header can now be customized in script settings.
- Lying in the description was reduced.