### PR TITLE
ollama-integration: rename to ai-local-backend-integration

### DIFF
--- a/ai-local-backend-integration/ai-local-backend-integration.qml
+++ b/ai-local-backend-integration/ai-local-backend-integration.qml
@@ -2,9 +2,11 @@ import QtQml 2.0
 import QOwnNotesTypes 1.0
 
 /**
- * This script provides integration for a local Ollama backend
+ * This script provides integration for a local AI backend
  * See: https://github.com/ollama/ollama
+ *      https://github.com/ggerganov/llama.cpp
  * List of models: https://github.com/ollama/ollama?tab=readme-ov-file#model-library
+ *                 https://github.com/ggerganov/llama.cpp#description
  * OpenAPI endpoint: https://ollama.com/blog/openai-compatibility or https://github.com/ollama/ollama/blob/main/docs/openai.md
  */
 Script {
@@ -16,9 +18,9 @@ Script {
         {
             "identifier": "baseUrl",
             "name": "API base URL",
-            "description": "The chat base URL of the Ollama API.",
+            "description": "The base URL of the local server.",
             "type": "string",
-            "default": "http://127.0.0.1:11434/v1/chat/completions",
+            "default": "http://127.0.0.1:11434",
         },
         {
             "identifier": "models",
@@ -36,10 +38,10 @@ Script {
     function openAiBackendsHook() {
         return [
             {
-                "id": "ollama",
-                "name": "Ollama",
-                "baseUrl": baseUrl,
-                "apiKey": "ollama",
+                "id": "local-ai",
+                "name": "Local AI",
+                "baseUrl": baseUrl + "/v1/chat/completions",
+                "apiKey": "local-ai",
                 "models": models.split(",")
             },
         ];

--- a/ai-local-backend-integration/info.json
+++ b/ai-local-backend-integration/info.json
@@ -1,0 +1,9 @@
+{
+  "name": "Local AI backend integration",
+  "identifier": "ai-local-backend-integration",
+  "script": "ai-local-backend-integration.qml",
+  "version": "0.0.2",
+  "minAppVersion": "24.6.2",
+  "authors": ["@pbek"],
+  "description" : "This script provides integration for an OpenAI-compatible local AI backend like <a href=\"https://github.com/ollama/ollama\">Ollama</a> or <a href=\"https://github.com/ggerganov/llama.cpp\">llama-cpp</a>."
+}

--- a/ollama-integration/info.json
+++ b/ollama-integration/info.json
@@ -1,9 +1,0 @@
-{
-  "name": "Ollama integration",
-  "identifier": "ollama-integration",
-  "script": "ollama-integration.qml",
-  "version": "0.0.2",
-  "minAppVersion": "24.6.2",
-  "authors": ["@pbek"],
-  "description" : "This script provides integration for a local <a href=\"https://github.com/ollama/ollama\">Ollama</a> AI backend."
-}


### PR DESCRIPTION
Any OpenAI-compatible backend is supported, so it would be better to maintain them in a single script and have seperate scripts for the ones that aren't compatible.

This would also be clearer for users which might wrongly assume that only one backend is supported.

This change also automatically adds the OpenAI endpoint to the base URL because all compatible backends support it already. Therefore, users only need to provide the local address.