### PR TITLE
Add script: "New note namer"

### DIFF
--- a/new-note-namer/info.json
+++ b/new-note-namer/info.json
@@ -1,0 +1,10 @@
+{
+  "name": "New note namer",
+  "identifier": "new-note-namer",
+  "script": "new-note-namer.qml",
+  "authors": ["@diegovskytl"],
+  "platforms": ["linux", "macos", "windows"],
+  "version": "0.0.1",
+  "minAppVersion": "17.06.2",
+  "description": "Enables a dialog window (or two) so the user can choose the note title and file name at the moment of creation. <br> Specially useful when the 'Allow note file name to be different to note title. \n No more cumbersome renaming :)"
+}

--- a/new-note-namer/new-note-namer.qml
+++ b/new-note-namer/new-note-namer.qml
@@ -1,0 +1,73 @@
+import QtQml 2.0
+import QOwnNotesTypes 1.0
+
+/**
+ * This script allows to set both the title and headline of a new note.
+ Recommended for when "headline == file name" option is enabled.
+ Avoids cumbersome renaming and title editing.
+ */
+QtObject {
+    property bool extraDialogForFileName;
+    property variant settingsVariables: [
+            {
+                'identifier': 'extraDialogForFileName',
+                'name': 'Extra dialog for note title',
+                'description': 'Show an additional dialog window so user can write a file name different to the note title.',
+                'type': 'boolean',
+                'default': 'false',
+            },
+        ];
+
+  function init() {
+    script.log("New-note-namer active");
+  }
+
+  function newNamer(title, message, defaultText) {
+    var name = script.inputDialogGetText(
+      title, message, defaultText);
+
+    script.log("input name: " + name);
+
+    if (name == "" || name == null){
+      name = defaultText;
+    }
+
+    return name;
+  }
+
+  function handleNewNoteHeadlineHook(note) {
+
+    var newName = newNamer("New note", "New note title", "Title");
+    script.log(note.fileCreated)
+    script.log(note.fileLastModified)
+
+    return "# " + newName;
+  }
+
+  function handleNoteTextFileNameHook(note) {
+          script.log("note name: " + note.name);
+          script.log("file name: "+ note.fileName);
+          script.log(note.fileCreated)
+          script.log(note.fileLastModified)
+
+          var noteLines = note.noteText.split("\n");
+          var firstLine = noteLines[0];
+          var noteTitle = firstLine.slice(2)
+
+          script.log("note title: " + noteTitle)
+
+          // right when a note is created, the fileCreated property value is 'Invald Date'
+          // this blocks the hook to further change the note file name if the note title is changed
+          if (note.fileCreated != "Invalid Date"){
+              return ""
+          }
+
+          if (extraDialogForFileName){
+            return newNamer("New note", "New file name", "File name")
+          }
+          else{
+              return noteTitle
+          }
+      }
+
+}


### PR DESCRIPTION
This script is for those who activate the option "Allow note name to be different than title" to choose the file name and file title through a pop up dialog window, instead of having to rightclick the note.

It has a checkbox for the user to choose between 2 options:
- one dialog window input defines both note name and title
- Note name and note title have separate pop ups, making it easy to be different from the other.