### PR TITLE
Journal format

### DIFF
--- a/journal-entry/info.json
+++ b/journal-entry/info.json
@@ -3,8 +3,8 @@
   "identifier": "journal-entry",
   "script": "journal-entry.qml",
   "resources": ["calendar-window.qml"], 
-  "version": "1.6.0",
+  "version": "1.7.0",
   "minAppVersion": "20.4.16",
-  "authors": ["@pbek", "@sanderboom", "@kantrol"],
-  "description" : "This script creates menu items and buttons to create or jump to the current date's (or tomorrow's date) journal entry. It also allows to open a calendar to choose the date."
+  "authors": ["@pbek", "@sanderboom", "@kantrol", "@nico2sh"],
+  "description" : "This script creates menu items and buttons to create or jump to the current date's (or tomorrow's date) journal entry. And formats the title based on a date placeholder. It also allows to open a calendar to choose the date."
 }

--- a/journal-entry/journal-entry.qml
+++ b/journal-entry/journal-entry.qml
@@ -128,8 +128,6 @@ QtObject {
             });
         }
 
-        // var headline = "Journal " + m.getFullYear() + ("0" + (m.getMonth()+1)).slice(-2) + ("0" + m.getDate()).slice(-2);
-
         var fileName = headline + ".md";
 
         // Check if we already have the requested journal entry.
@@ -167,7 +165,7 @@ QtObject {
             }
 
             // Create the new journal note.
-            script.createNote(headline + "\n================\n\n" + noteBodyTemplate);
+            script.createNote(headline + "\n" + '='.repeat(Math.max(4, headline.length)) + "\n\n" + noteBodyTemplate);
             
             const currentNote = script.currentNote();
 

--- a/journal-entry/journal-entry.qml
+++ b/journal-entry/journal-entry.qml
@@ -31,7 +31,7 @@ QtObject {
         {
             "identifier": "noteTitleFormat",
             "name": "Title Format",
-            "description": "How the journal title should be formatted, use date format placeholders inside curly braces. YYYY: for the year, MM: for the month, DD: for the day, WW: for the week. For example \"Journal {YYYYMMDD}\" will return \"Journal 20240928\". You can have monthly or weekly journals instead of daily by formatting the date to the week or monthly level.",
+            "description": "How the journal title should be formatted, use date format placeholders inside curly braces. YYYY: year, MM: month, DD: day, WW: week, HH: hours, mm: minutes, ss: seconds. For example \"Journal {YYYYMMDD}\" will return \"Journal 20240928\". You can have monthly or weekly journals instead of daily by formatting the date to the week or monthly level, or one journal file per entry by including the hour, minutes and seconds.",
             "type": "string",
             "default": "Journal {YYYYMMDD}",
         },
@@ -94,17 +94,26 @@ QtObject {
         let month = date.getMonth() + 1; //getMonth() returns 0-11 so we must add 1
         let week = getWeekNumber(date);
         let year = date.getFullYear();
+        let hours = date.getHours();
+        let minutes = date.getMinutes();
+        let seconds = date.getSeconds();
 
         // If day and month are less than 10, add a leading zero
         day = (day < 10) ? '0' + day : day;
         month = (month < 10) ? '0' + month : month;
         week = (week < 10) ? '0' + week : week;
+        hours = (hours < 10) ? '0' + hours : hours;
+        minutes = (minutes < 10) ? '0' + minutes : minutes;
+        seconds = (seconds < 10) ? '0' + seconds : seconds;
 
         // Replace format placeholders by actual values
         format = format.replace('WW', week);
         format = format.replace('MM', month);
         format = format.replace('DD', day);
         format = format.replace('YYYY', year);
+        format = format.replace('HH', hours);
+        format = format.replace('mm', minutes);
+        format = format.replace('ss', seconds);
 
         return format;
     }

--- a/journal-entry/journal-entry.qml
+++ b/journal-entry/journal-entry.qml
@@ -3,13 +3,14 @@ import com.qownnotes.noteapi 1.0
 
 /**
  * This script creates a menu item and a button to create or jump to the current date's journal entry
+ * based on a pre-defined format
  */
 QtObject {
     id: journalEntry
     property string defaultFolder;
     property string defaultTags;
-    property bool singleJournalPerDay;
     property string noteBodyTemplate;
+    property string noteTitleFormat;
     property var dialog;
 
     property variant settingsVariables: [
@@ -28,11 +29,11 @@ QtObject {
             "default": "journal",
         },
         {
-            "identifier": "singleJournalPerDay",
-            "name": "Single journal per day",
-            "description": "Create a single journal per day instead of always adding a new journal.",
-            "type": "boolean",
-            "default": "true",
+            "identifier": "noteTitleFormat",
+            "name": "Title Format",
+            "description": "How the journal title should be formatted, use date format placeholders inside curly braces. YYYY: for the year, MM: for the month, DD: for the day, WW: for the week. For example \"Journal {YYYYMMDD}\" will return \"Journal 20240928\". You can have monthly or weekly journals instead of daily by formatting the date to the week or monthly level.",
+            "type": "string",
+            "default": "Journal {YYYYMMDD}",
         },
         {
             "identifier": "noteBodyTemplate",
@@ -47,11 +48,7 @@ QtObject {
      * Initializes the custom action
      */
     function init() {
-        if (singleJournalPerDay) {
-            script.registerCustomAction("journalEntry", "Create or open a journal entry for today", "Journal", "document-new");
-        } else {
-            script.registerCustomAction("journalEntry", "Create a journal entry", "Journal", "document-new");
-        }
+        script.registerCustomAction("journalEntry", "Create a journal entry", "Journal", "document-new");
 
         // Create custom action for 'Create or open journal entry for tomorrow'.
         script.registerCustomAction("journalEntryTomorrow", "Create or open a journal entry for tomorrow", "Journal tomorrow", "document-multiple")
@@ -83,14 +80,46 @@ QtObject {
         }
     }
 
-    function createOrJumpToJournalEntry(m, identifier) {
-        var headline = "Journal " + m.getFullYear() + ("0" + (m.getMonth()+1)).slice(-2) + ("0" + m.getDate()).slice(-2);
+    function getWeekNumber(d) {
+        // Copy date so don't modify original
+        d = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+        d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay()||7));
+        var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
+        var weekNo = Math.ceil(( ( (d - yearStart) / 86400000) + 1)/7);
+        return weekNo;
+    }
 
-        // When the configuration option "singleJournalPerDay" is not selected, and we are not creating a journal entry
-        // for tomorrow, create journal entry including time.
-        if (!singleJournalPerDay && identifier != "journalEntryTomorrow") {
-            headline = headline + "T"+ ("0" + m.getHours()).slice(-2) + ("0" + m.getMinutes()).slice(-2) + ("0" + m.getSeconds()).slice(-2);
+    function formatDate(date, format) {
+        let day = date.getDate();
+        let month = date.getMonth() + 1; //getMonth() returns 0-11 so we must add 1
+        let week = getWeekNumber(date);
+        let year = date.getFullYear();
+
+        // If day and month are less than 10, add a leading zero
+        day = (day < 10) ? '0' + day : day;
+        month = (month < 10) ? '0' + month : month;
+        week = (week < 10) ? '0' + week : week;
+
+        // Replace format placeholders by actual values
+        format = format.replace('WW', week);
+        format = format.replace('MM', month);
+        format = format.replace('DD', day);
+        format = format.replace('YYYY', year);
+
+        return format;
+    }
+
+    function createOrJumpToJournalEntry(m, identifier) {
+        var headline;
+        if (!noteTitleFormat || noteTitleFormat.length == 0) {
+            headline = "Journal " + m.getFullYear() + ("0" + (m.getMonth()+1)).slice(-2) + ("0" + m.getDate()).slice(-2);
+        } else {
+            headline = noteTitleFormat.replace(/{[^}]*}/g, function(match) { 
+                return formatDate(m, match.slice(1, -1)); 
+            });
         }
+
+        // var headline = "Journal " + m.getFullYear() + ("0" + (m.getMonth()+1)).slice(-2) + ("0" + m.getDate()).slice(-2);
 
         var fileName = headline + ".md";
 


### PR DESCRIPTION
Hi! I wanted to have a different format for the Journal Entries, and I was a bit frustrated renaming the entry each time, so I added the option of formatting the journal. Now the option of "one journal entry per day" is not needed as by the format one can create the format to match up to the second.

The format is configured putting it under curly braces as in `{YYYY-MM-DD}`