### PR TITLE
Add option to new-note-namer, to underline the heading instead of highlighting it with #

### DIFF
--- a/new-note-namer/info.json
+++ b/new-note-namer/info.json
@@ -2,7 +2,7 @@
   "name": "New note namer",
   "identifier": "new-note-namer",
   "script": "new-note-namer.qml",
-  "authors": ["@diegovskytl,@Mystechry"],
+  "authors": ["@diegovskytl", "@Mystechry"],
   "platforms": ["linux", "macos", "windows"],
   "version": "0.0.2",
   "minAppVersion": "17.06.2",

--- a/new-note-namer/info.json
+++ b/new-note-namer/info.json
@@ -2,9 +2,9 @@
   "name": "New note namer",
   "identifier": "new-note-namer",
   "script": "new-note-namer.qml",
-  "authors": ["@diegovskytl"],
+  "authors": ["@diegovskytl,@Mystechry"],
   "platforms": ["linux", "macos", "windows"],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "minAppVersion": "17.06.2",
   "description": "Enables a dialog window (or two) so the user can choose the note title and file name at the moment of creation. <br> Specially useful when the 'Allow note file name to be different to note title. \n No more cumbersome renaming :)"
 }

--- a/new-note-namer/new-note-namer.qml
+++ b/new-note-namer/new-note-namer.qml
@@ -50,7 +50,7 @@ QtObject {
     script.log(note.fileLastModified)
 
     if (underlineHeading){
-          return newName + "\n========================"
+          return newName + "\n" + "=".repeat(newName.length);
     } else {
           return "# " + newName;
     }
@@ -64,7 +64,10 @@ QtObject {
 
           var noteLines = note.noteText.split("\n");
           var firstLine = noteLines[0];
-          var noteTitle = firstLine.slice(2)
+          var noteTitle = firstLine.slice(2) // Remove the preceding "# "
+          if (underlineHeading){             // Underlined headings use the entire first line
+              noteTitle = firstLine;
+          }
 
           script.log("note title: " + noteTitle)
 
@@ -75,7 +78,7 @@ QtObject {
           }
 
           if (extraDialogForFileName){
-            return newNamer("New note", "New file name", "File name")
+              return newNamer("New note", "New file name", "File name")
           }
           else{
               return noteTitle

--- a/new-note-namer/new-note-namer.qml
+++ b/new-note-namer/new-note-namer.qml
@@ -8,11 +8,19 @@ import QOwnNotesTypes 1.0
  */
 QtObject {
     property bool extraDialogForFileName;
+    property bool underlineHeading;
     property variant settingsVariables: [
             {
                 'identifier': 'extraDialogForFileName',
                 'name': 'Extra dialog for note title',
                 'description': 'Show an additional dialog window so user can write a file name different to the note title.',
+                'type': 'boolean',
+                'default': 'false',
+            },
+            {
+                'identifier': 'underlineHeading',
+                'name': 'Underline heading',
+                'description': 'Highlight the first line by underlining it with =, if not checked, use a preceding # instead.',
                 'type': 'boolean',
                 'default': 'false',
             },
@@ -41,7 +49,11 @@ QtObject {
     script.log(note.fileCreated)
     script.log(note.fileLastModified)
 
-    return "# " + newName;
+    if (underlineHeading){
+          return newName + "\n========================"
+    } else {
+          return "# " + newName;
+    }
   }
 
   function handleNoteTextFileNameHook(note) {

--- a/new-note-namer/new-note-namer.qml
+++ b/new-note-namer/new-note-namer.qml
@@ -49,7 +49,7 @@ QtObject {
     script.log(note.fileCreated)
     script.log(note.fileLastModified)
 
-    if (underlineHeading){
+    if (underlineHeading) {
           return newName + "\n" + "=".repeat(newName.length);
     } else {
           return "# " + newName;
@@ -77,10 +77,9 @@ QtObject {
               return ""
           }
 
-          if (extraDialogForFileName){
+          if (extraDialogForFileName) {
               return newNamer("New note", "New file name", "File name")
-          }
-          else{
+          } else {
               return noteTitle
           }
       }


### PR DESCRIPTION
The script `new-note-namer` deviates from how QOwnNotes highlights the automatically created heading. Instead of underlining the first line with `======`, it precedes it with `#`.

I prefer the way how QOwnNotes highlights the first line, so I added a checkbox to `new-note-namer`'s settings that restores the default behavior.

I have done some testing and did not notice any regression. Please let me know, if anything looks suspicious.

I do not have any particular preference for which heading style shall be used as the default. I suggest to default to my style and underline the first line with  `=====`, so that it matches QOwnNotes default aesthetics. However, I do not have a strong opinion on this and respect the author's preference to default to `#`, so I use that for default. Feel free, to reject the PR, if I shall use `=====` as default.