### PR TITLE
Remove deprecated option in Booklet Export defaults.yaml

### DIFF
--- a/word-pdf-booklet-export/defaults.yaml
+++ b/word-pdf-booklet-export/defaults.yaml
@@ -4,8 +4,6 @@ to: odt
 standalone: true
 self-contained: false
 
-strip-empty-paragraphs: true
-
 # lf, crlf, or native
 eol: lf
 

--- a/word-pdf-booklet-export/info.json
+++ b/word-pdf-booklet-export/info.json
@@ -3,9 +3,9 @@
   "identifier": "word-pdf-booklet-export",
   "script": "word-pdf-booklet-export.qml",
   "resources": ["defaults.yaml", "reference.odt"],
-  "authors": ["@student4life", "@letterus"],
+  "authors": ["@student4life", "@letterus", "@willowbit"],
   "platforms": ["linux", "macos", "windows"],
-  "version": "0.1.1",
+  "version": "0.1.2",
   "minAppVersion": "22.11.6",
   "description" : "This script exports the current note to at least three file formats. First it creates a .docx/Word file using <a href=\"http://pandoc.org/installing.html\">Pandoc</a> and <a href=\"https://libreoffice.org/download/download/\">LibreOffice</a>. Finally <a href=\"https://ctan.org/pkg/pdfbook2l\">pdfbook2</a> is used to create a short-edge double-sided printable booklet for paper size A4.\n\nPandoc is run from the folder containing the current note file.\n\nA defaults.yaml and reference.odt files in the current note directory can be used to fine tune the export. Otherwise the configuration and template files provided within the directory of this script are used.\n\nThe odt file used for docx and pdf file creation is removed during the process. If you want to keep it comment out the corresponding lines of script."
 }


### PR DESCRIPTION
Remove deprecated --strip-empty-paragraphs option that causes pandoc to exit and the script to fail.

https://disco.uv.es/disco_docs/wikibase/doc/fra/pandoc_manual_2.7.3.wiki?7