### PR TITLE
Add url2markup script: convert bare URLs to Markdown links

### DIFF
--- a/url2markup/info.json
+++ b/url2markup/info.json
@@ -1,0 +1,10 @@
+{
+  "name": "URL to Markdown Link",
+  "identifier": "url2markup",
+  "script": "url2markup.qml",
+  "authors": ["@rkratky"],
+  "platforms": ["linux", "macos", "windows"],
+  "version": "0.1.0",
+  "minAppVersion": "20.0.0",
+  "description": "Converts bare URLs to proper Markdown links <code>[Page Title](url)</code> by fetching each page's <code>&lt;title&gt;</code> tag.<br><br><b>Function 1 — selection to links</b><br>Select text containing bare URLs, then right-click › <i>Convert URLs in selection to Markdown links</i> (or assign a shortcut such as <i>Ctrl+Shift+K</i> in Settings › Shortcuts).<br><br><b>Function 2 — clipboard URL to link</b><br>Copy a URL to the clipboard, then invoke <i>Paste clipboard URL as Markdown link</i> (suggested shortcut: <i>Ctrl+Shift+W</i>, assign in Settings › Shortcuts) to insert a resolved Markdown link at the cursor position.<br><br>Smart title trimming is applied:<br>• Site-name suffixes (<i>Article – Site</i>, <i>Article | Site</i>, etc.) are stripped.<br>• GitHub / GitLab / Bitbucket / Codeberg issue and pull-request metadata (<i>by user · PR #N · owner/repo</i>) is removed, leaving only the actual issue or PR title."
+}

--- a/url2markup/url2markup.qml
+++ b/url2markup/url2markup.qml
@@ -1,0 +1,283 @@
+import QtQml 2.0
+
+/**
+ * url2markup — Convert bare URLs to Markdown links
+ *
+ * Two functions:
+ *
+ * 1. Selection → Markdown links  (custom action / context menu)
+ *    Select text containing bare URLs, then invoke the action.  Every bare URL
+ *    in the selection is replaced with a [Page Title](url) Markdown link.
+ *    The page title is fetched live; smart trimming strips site-name suffixes
+ *    and code-hosting metadata (issue/PR numbers, "by user", etc.).
+ *    Suggested keyboard shortcut: assign Ctrl+Shift+K in
+ *    QOwnNotes Settings › Shortcuts › "Convert URLs in selection to Markdown links".
+ *
+ * 2. Clipboard URL → Markdown link  (custom action)
+ *    Copy a URL to the clipboard, then invoke the action to insert a resolved
+ *    [Page Title](url) link at the cursor position.
+ *    Suggested keyboard shortcut: assign Ctrl+Shift+W in
+ *    QOwnNotes Settings › Shortcuts › "Paste clipboard URL as Markdown link".
+ */
+QtObject {
+
+    // ------------------------------------------------------------------
+    // HTML entity decoding
+    // ------------------------------------------------------------------
+
+    /**
+     * Converts a Unicode code point to a JS string, correctly handling
+     * supplementary characters (code points > U+FFFF) via surrogate pairs
+     * for engines that do not yet support String.fromCodePoint.
+     */
+    function codePointToString(cp) {
+        if (typeof String.fromCodePoint === "function") return String.fromCodePoint(cp);
+        if (cp <= 0xFFFF) return String.fromCharCode(cp);
+        // Construct surrogate pair for code points above the BMP.
+        cp -= 0x10000;
+        return String.fromCharCode((cp >> 10) + 0xD800, (cp & 0x3FF) + 0xDC00);
+    }
+
+    function decodeHtmlEntities(str) {
+        return str
+            .replace(/&amp;/g,  "&")
+            .replace(/&lt;/g,   "<")
+            .replace(/&gt;/g,   ">")
+            .replace(/&quot;/g, '"')
+            .replace(/&#39;/g,  "'")
+            .replace(/&apos;/g, "'")
+            .replace(/&nbsp;/g, " ")
+            .replace(/&#(\d+);/g,        function(m, n) { return codePointToString(parseInt(n, 10)); })
+            .replace(/&#x([0-9a-fA-F]+);/g, function(m, h) { return codePointToString(parseInt(h, 16)); });
+    }
+
+    // ------------------------------------------------------------------
+    // Smart title trimming
+    // ------------------------------------------------------------------
+
+    function isCodeHostUrl(url) {
+        return /^https?:\/\/(?:www\.)?(github\.com|gitlab\.com|bitbucket\.org|codeberg\.org)/i.test(url);
+    }
+
+    /**
+     * Trims a raw <title> string to a concise, clean link label.
+     *
+     * Code-hosting URLs (GitHub, GitLab, Bitbucket, Codeberg):
+     *   • Strips the "by user · Pull Request/Issue/Discussion/Merge Request #N · owner/repo"
+     *     suffix that these platforms append to page titles.
+     *
+     * All other URLs:
+     *   • Removes a trailing " | Site Name", " · Site", " — Site", or " – Site" suffix.
+     *   • For a single " - " separator (plain hyphen), strips the suffix only when it
+     *     appears exactly once (avoids mangling titles that legitimately contain hyphens).
+     *   • Falls back to the full title when no recognisable separator is present.
+     */
+    function smartTrimTitle(url, title) {
+        if (isCodeHostUrl(url)) {
+            // "Fix bug by user · Pull Request #N · owner/repo" → "Fix bug"
+            // "Fix bug · Issue #N · owner/repo"               → "Fix bug"
+            title = title.replace(
+                /(\s+by\s+\S+)?\s+[·•]\s+(?:Pull Request|Issue|Discussion|Merge Request)\s+#?\d+\s+[·•]\s+.*$/i,
+                ""
+            );
+            // Strip any remaining " · Something · GitHub/GitLab/…" tail
+            title = title.replace(
+                /\s+[·•]\s+.*?\s+[·•]\s+(?:GitHub|GitLab|Bitbucket|Codeberg)\s*$/i,
+                ""
+            );
+            // Strip simple " · GitHub" etc.
+            title = title.replace(
+                /\s+[·•]\s+(?:GitHub|GitLab|Bitbucket|Codeberg)\s*$/i,
+                ""
+            );
+            return title.trim();
+        }
+
+        // General: strip the site-name suffix that follows the last strong separator.
+        var strongSeps = [" | ", " · ", " — ", " – "];
+        for (var i = 0; i < strongSeps.length; i++) {
+            var idx = title.lastIndexOf(strongSeps[i]);
+            if (idx > 0) {
+                return title.substring(0, idx).trim();
+            }
+        }
+
+        // Plain hyphen: only strip when there is exactly one occurrence.
+        var hyphenIdx = title.lastIndexOf(" - ");
+        if (hyphenIdx > 0 && title.indexOf(" - ") === hyphenIdx) {
+            return title.substring(0, hyphenIdx).trim();
+        }
+
+        return title;
+    }
+
+    // ------------------------------------------------------------------
+    // URL helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Escapes characters that are significant inside a Markdown link label
+     * ( [ and ] would break [label](url) syntax) and collapses newlines to
+     * spaces so multi-line titles don't corrupt the note text.
+     */
+    function escapeMarkdownLinkText(text) {
+        return text
+            .replace(/\r?\n|\r/g, " ")
+            .replace(/\[/g, "\\[")
+            .replace(/\]/g, "\\]");
+    }
+
+    /**
+     * Strips trailing sentence-punctuation characters that are almost certainly
+     * not part of the URL.  For closing parentheses, only strips extras that
+     * are unbalanced (so Wikipedia-style URLs with "(…)" in the path are kept
+     * intact).
+     */
+    function cleanUrlTrailing(url) {
+        url = url.replace(/[.,;:!?]+$/, "");
+
+        var opens  = (url.match(/\(/g) || []).length;
+        var closes = (url.match(/\)/g) || []).length;
+        while (closes > opens && url.length > 0 && url[url.length - 1] === ")") {
+            url = url.slice(0, -1);
+            closes--;
+        }
+
+        return url;
+    }
+
+    /**
+     * Downloads a URL and returns the cleaned page title, or the URL itself
+     * when the title cannot be determined.
+     */
+    function fetchPageTitle(url) {
+        var html = script.downloadUrlToString(url);
+        if (!html) return url;
+
+        var m = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html);
+        if (!m || !m[1]) return url;
+
+        var title = decodeHtmlEntities(m[1].trim());
+        if (!title) return url;
+
+        return escapeMarkdownLinkText(smartTrimTitle(url, title) || url);
+    }
+
+    // ------------------------------------------------------------------
+    // Core conversion: bare URLs → Markdown links
+    // ------------------------------------------------------------------
+
+    /**
+     * Replaces every bare URL in `text` with a [Page Title](url) Markdown link.
+     * Skips URLs that are already part of a Markdown link ([…](url)) or wrapped
+     * in angle brackets (<url>).
+     */
+    function convertUrlsInText(text) {
+        // Allow ( and ) inside the URL so that Wikipedia-style paths survive;
+        // cleanUrlTrailing() will remove unbalanced trailing ) afterwards.
+        var urlRe = /https?:\/\/[^\s\]<>"]+/g;
+        var result    = "";
+        var lastIndex = 0;
+        var match;
+
+        while ((match = urlRe.exec(text)) !== null) {
+            var raw   = match[0];
+            var start = match.index;
+            var end   = start + raw.length;
+
+            // Already inside a Markdown link: ]( url )
+            if (start >= 2 && text.substring(start - 2, start) === "](") {
+                result    += text.substring(lastIndex, end);
+                lastIndex  = end;
+                continue;
+            }
+
+            // Already inside an angle-bracket link: <url>
+            if (start >= 1 && text.charAt(start - 1) === "<") {
+                result    += text.substring(lastIndex, end);
+                lastIndex  = end;
+                continue;
+            }
+
+            var cleanUrl     = cleanUrlTrailing(raw);
+            var trailingPunct = raw.substring(cleanUrl.length);
+            var linkText     = fetchPageTitle(cleanUrl);
+
+            result    += text.substring(lastIndex, start);
+            result    += "[" + linkText + "](" + cleanUrl + ")";
+            result    += trailingPunct;
+            lastIndex  = end;
+        }
+
+        result += text.substring(lastIndex);
+        return result;
+    }
+
+    // ------------------------------------------------------------------
+    // Initialisation: register custom actions
+    // ------------------------------------------------------------------
+
+    function init() {
+        // Function 1 — selection to Markdown links
+        // Suggested shortcut: Ctrl+Shift+K (assign in Settings › Shortcuts)
+        script.registerCustomAction(
+            "url2markup-selection",
+            qsTr("Convert URLs in selection to Markdown links"),
+            "",            // no toolbar button label
+            "insert-link", // freedesktop icon
+            true,          // show in note-edit context menu
+            true,          // hide button in toolbar
+            false          // not in note-list context menu
+        );
+
+        // Function 2 — clipboard URL to Markdown link
+        // Suggested shortcut: Ctrl+Shift+W (assign in Settings › Shortcuts)
+        script.registerCustomAction(
+            "url2markup-clipboard",
+            qsTr("Paste clipboard URL as Markdown link"),
+            "",
+            "insert-link",
+            true,
+            true,
+            false
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Custom action handler
+    // ------------------------------------------------------------------
+
+    function customActionInvoked(identifier) {
+        if (identifier === "url2markup-selection") {
+            var sel = script.noteTextEditSelectedText();
+            if (!sel || sel.trim() === "") {
+                script.informationMessageBox(
+                    qsTr("Please select text containing bare URLs first."),
+                    qsTr("URL → Markdown Link")
+                );
+                return;
+            }
+
+            var converted = convertUrlsInText(sel);
+            if (converted !== sel) {
+                script.noteTextEditWrite(converted);
+            }
+            return;
+        }
+
+        if (identifier === "url2markup-clipboard") {
+            var clipUrl = script.clipboard().trim();
+            if (!/^https?:\/\/\S+$/i.test(clipUrl)) {
+                script.informationMessageBox(
+                    qsTr("Clipboard does not contain a single bare URL."),
+                    qsTr("URL → Markdown Link")
+                );
+                return;
+            }
+
+            var linkText = fetchPageTitle(clipUrl);
+            script.noteTextEditWrite("[" + linkText + "](" + clipUrl + ")");
+        }
+    }
+
+}


### PR DESCRIPTION
Two custom actions (available in the note-edit context menu; keyboard shortcuts assigned via QOwnNotes Settings › Shortcuts):

* url2markup-selection  (suggested: Ctrl+Shift+K)
    Converts every bare URL in the current text selection to a `[Page Title](url)` Markdown link.  Skip URLs already wrapped in `[text](url)` or `<url>`.

* url2markup-clipboard  (suggested: Ctrl+Shift+W)
    Reads a bare URL from the clipboard and inserts a resolved `[Page Title](url)` Markdown link at the cursor position.

Title extraction fetches each page's <title> tag with smart trimming:
  - Code-hosting platforms (GitHub, GitLab, Bitbucket, Codeberg): strips the trailing 'by user · PR/Issue #N · owner/repo' metadata, keeping only the actual issue or pull-request title.
  - General pages: removes the site-name suffix after the last strong separator (|, ·, —, –); for a plain ' - ' separator, only strips when it appears exactly once to avoid mangling hyphenated titles.
  - Falls back to the full title when no separator is found, and to the raw URL when the page cannot be fetched or has no title.

Additional robustness:
  - HTML entities decoded, including supplementary code points above U+FFFF via String.fromCodePoint / surrogate-pair fallback.
  - Link-text sanitised: [ and ] escaped, newlines collapsed to spaces.
  - Unbalanced trailing ) stripped from matched URLs so Wikipedia-style paths with balanced parentheses are preserved intact.

Keyboard shortcuts verified free against pbek/QOwnNotes mainwindow.ui and mainwindow.cpp (Ctrl+Shift+K and Ctrl+Shift+W are both unassigned).

-----------

Disclosure: This is 95% done by AI. I wanted the script to scratch a personal itch and to plug a perceived gap in the app feature set. If AI-written contributions are not welcome/allowed in the repo, I totally understand.