### PR TITLE
Prevent double newline after heading atx-headline.qml

### DIFF
--- a/atx-headline/atx-headline.qml
+++ b/atx-headline/atx-headline.qml
@@ -18,7 +18,7 @@ QtObject {
      * @return {string} the headline of the note
      */
     function handleNewNoteHeadlineHook(headline) {
-        var text = "# " + headline + "\n";
+        var text = "# " + headline;
 
         return text;
     }

--- a/atx-headline/info.json
+++ b/atx-headline/info.json
@@ -2,9 +2,9 @@
   "name": "ATX Headline",
   "identifier": "atx-headline",
   "script": "atx-headline.qml",
-  "authors": ["@dohliam"],
+  "authors": ["@dohliam", "@louwers"],
   "platforms": ["linux", "macos", "windows"],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "minAppVersion": "20.6.0",
   "description": "Fix new note headlines to use atx rather than setext headers. More information can be found at <a href='https://github.com/qownnotes/scripts/wiki/atx-headline'>atx-headline</a>."
 }


### PR DESCRIPTION
The current version inserts two empty lines before the cursor, instead of just one (which is more common).