### PR TITLE
feat(in-note-text-tagging): add option to detect tags only at line start

### DIFF
--- a/in-note-text-tagging/in-note-text-tagging.qml
+++ b/in-note-text-tagging/in-note-text-tagging.qml
@@ -179,9 +179,7 @@ Script {
         // When tagsAtLineStartOnly is enabled: only matches at the start of a line.
         // Otherwise: also matches tags preceded by whitespace (inline tags).
         // Group 1: leading anchor/whitespace, preserved on replace. Group 2: the matched marker.
-        var tagRegExp = tagsAtLineStartOnly
-            ? RegExp("(^)(%1)%2(?=($|\\s)) ?".arg(pattern).arg(escapeRegExp(tagName).replace(/ /g, "_")), "m")
-            : RegExp("(^|\\s)(%1)%2(?=($|\\s)) ?".arg(pattern).arg(escapeRegExp(tagName).replace(/ /g, "_")), "m");
+        var tagRegExp = tagsAtLineStartOnly ? RegExp("(^)(%1)%2(?=($|\\s)) ?".arg(pattern).arg(escapeRegExp(tagName).replace(/ /g, "_")), "m") : RegExp("(^|\\s)(%1)%2(?=($|\\s)) ?".arg(pattern).arg(escapeRegExp(tagName).replace(/ /g, "_")), "m");
 
         switch (action) {
         // adds the tag "tagName" to the note

--- a/in-note-text-tagging/in-note-text-tagging.qml
+++ b/in-note-text-tagging/in-note-text-tagging.qml
@@ -59,12 +59,20 @@ Script {
             "type": "boolean",
             "default": "false"
         },
+        {
+            "identifier": "tagsAtLineStartOnly",
+            "name": "Only detect tags at the beginning of a line",
+            "description": "If enabled, only tags placed at the very start of a line are recognized (tags inline within text are ignored)",
+            "type": "boolean",
+            "default": "true"
+        },
     ]
     property bool useMarker1
     property string tagMarker
     property bool useMarker2
     property string tagMarker2
     property int maxTagLength
+    property bool tagsAtLineStartOnly
 
     // Returns the preferred marker for writing new tags: primary if enabled, otherwise secondary
     function writeMarker() {
@@ -168,8 +176,12 @@ Script {
 
         var noteText = note.noteText;
         // Match a specific known tag with any active marker.
-        // Group 1: leading space/newline, preserved on replace. Group 2: the matched marker.
-        var tagRegExp = RegExp("(^|\\s)(%1)%2(?=($|\\s)) ?".arg(pattern).arg(escapeRegExp(tagName).replace(/ /g, "_")), "m");
+        // When tagsAtLineStartOnly is enabled: only matches at the start of a line.
+        // Otherwise: also matches tags preceded by whitespace (inline tags).
+        // Group 1: leading anchor/whitespace, preserved on replace. Group 2: the matched marker.
+        var tagRegExp = tagsAtLineStartOnly
+            ? RegExp("(^)(%1)%2(?=($|\\s)) ?".arg(pattern).arg(escapeRegExp(tagName).replace(/ /g, "_")), "m")
+            : RegExp("(^|\\s)(%1)%2(?=($|\\s)) ?".arg(pattern).arg(escapeRegExp(tagName).replace(/ /g, "_")), "m");
 
         switch (action) {
         // adds the tag "tagName" to the note
@@ -237,7 +249,8 @@ Script {
             // a letter (including accented/Unicode) as first char.
             // Max length is controlled by tagBodyQuantifier().
             var excludedChars = allMarkers().map(escapeRegExp).join("");
-            var re = new RegExp("(?:^|\\s)" + pattern + "([a-zA-Z" + "\\u00C0-\\u024F" +   // Latin Extended A+B
+            var linePrefix = tagsAtLineStartOnly ? "^" : "(?:^|\\s)";
+            var re = new RegExp(linePrefix + pattern + "([a-zA-Z" + "\\u00C0-\\u024F" +   // Latin Extended A+B
             "\\u0250-\\u02AF" +   // IPA Extensions
             "\\u0370-\\u03FF" +   // Greek and Coptic
             "\\u0400-\\u052F" +   // Cyrillic + Supplement

--- a/in-note-text-tagging/info.json
+++ b/in-note-text-tagging/info.json
@@ -2,9 +2,9 @@
   "name": "@tag tagging in note text (experimental)",
   "identifier": "in-note-text-tagging",
   "script": "in-note-text-tagging.qml",
-  "authors": ["@Maboroshy", "@luginf"],
+  "authors": ["@Maboroshy", "@luginf", "@starze"],
   "platforms": ["linux", "macos", "windows"],
-  "version": "0.2.2",
+  "version": "0.3.0",
   "minAppVersion": "20.6.0",
   "description": "With this script you can <b>store your tags in your note-text</b>. Use tags like <i>@tag</i> or <i>@tag_one</i> for 'tag one' inside your note-text to tag your notes. You can change '@' to something else in script settings.\n\nYou also are able to use the functionality of the QOwnNotes user-interface to tag with this tags inside your note texts, like for adding a tag to the current note as well as bulk operations for adding and removing tags to your note. If you rename a tag inside QOwnNotes the text-tags in your notes are also updated.\n\nIf you start writing a tag you can also use the autocompleter to get a list of already existing tags.\n\nYou can also use this script as template for implementing your own, unique tagging mechanism.\n\n<b>If you install this script you will loose all links between notes and tags and instead your in-note tags will be used!\n\nThis functionality is still experimental!</b>\nPlease report your experiences."
 }


### PR DESCRIPTION
This pull request introduces an option that allows tag detection to be restricted to tags at the beginning of a line.

I keep many notes where I copy and paste things like code snippets or comments containing @ or #.

For example:

```
...
npm install @company/module
...
```

This switch improves auto tag detection for such scenarios a lot.
The downside, when enabled, is that it is no longer possible to include multiple tags on a single line. However, I believe the trade-off is worth it. Those who prefer the previous behavior can simply keep using the existing toggle.