### PR TITLE
Bug fix — keyboard focus lost after custom actions (txt2tags-it.qml)

### DIFF
--- a/txt2tags-it/info.json
+++ b/txt2tags-it/info.json
@@ -4,7 +4,7 @@
   "script": "txt2tags-it.qml",
   "resources": ["markdown-it.js", "markdown-it-txt2tags.js"],
   "authors": ["@luginf"],
-  "version": "0.1",
+  "version": "0.1.1",
   "minAppVersion": "26.4.11",
   "description": "This script, based on markdown-it, replaces the default markdown renderer with markdown-it AND also with the txt2tags syntax.\n\n<b>Dependencies</b>\n<a href=\"https://github.com/markdown-it/markdown-it\">markdown-it.js</a> (v8.4.2 bundled with the script)\n\n<b>Usage</b>\nFor the possible configuration options check <a href=\"https://github.com/markdown-it/markdown-it/tree/main/lib/presets\">here</a>.\n\n<b>Important</b>\nThis script currently only works with <a href=\"https://github.com/qownnotes/scripts/issues/77\"><b>legacy media links</b></a>. You can turn them on in the <i>General Settings</i>.\n\nImportant note: You need to use legacy image linking with this script, otherwise there will be no images shown in the preview!"
 }

--- a/txt2tags-it/markdown-it-txt2tags.js
+++ b/txt2tags-it/markdown-it-txt2tags.js
@@ -283,7 +283,10 @@ var markdownitTxt2tags;
       function (state, silent) {
         var pos = state.pos;
         var src = state.src;
-        // Must start with a URL scheme (letters then "://")
+        // Fast-fail: scheme must start with an ASCII letter
+        var ch = src.charCodeAt(pos);
+        if (!((ch >= 0x41 && ch <= 0x5a) || (ch >= 0x61 && ch <= 0x7a)))
+          return false;
         var match = /^[a-zA-Z][\w+\-.]*:\/\/[^\s\]]*/.exec(src.slice(pos));
         if (!match) return false;
         var url = match[0];

--- a/txt2tags-it/txt2tags-it.qml
+++ b/txt2tags-it/txt2tags-it.qml
@@ -47,6 +47,10 @@ QtObject {
     property bool useTxt2tagsPlugin
     property bool useEditorHighlighting
     property bool useSetextHeadings
+    property bool _isWindows: false
+    property variant _headRe
+    property variant _urlAttrRe
+    property string _cssInject: "table {border-spacing: 0; border-style: solid; border-width: 1px; border-collapse: collapse; margin-top: 0.5em;} th, td {padding: 0 5px;} del {text-decoration: line-through;}"
 
     function init() {
         var optionsObj = eval("(" + options + ")");
@@ -84,6 +88,10 @@ QtObject {
             // Comment: % until end of line
             script.addHighlightingRule("^%.*$", "%", 11);
         }
+
+        _isWindows = script.platformIsWindows();
+        _headRe = /<head>[\s\S]*?<\/head>/;
+        _urlAttrRe = /(\b(?:src|href|data-[\w-]+)\s*=\s*)(["'])([^"']+)\2/gi;
 
         //Allow file:// url scheme
         var validateLinkOrig = md.validateLink;
@@ -160,6 +168,7 @@ QtObject {
             applyHeading(3);
             break;
         }
+        mainWindow.focusNoteTextEdit();
     }
 
     /**
@@ -179,10 +188,11 @@ QtObject {
         var mdHtml = md.render(note.noteText);
         //Insert root folder in attachments and media relative urls
         var path = script.currentNoteFolderPath();
-        if (script.platformIsWindows())
+        if (_isWindows)
             path = "/" + path;
 
-        mdHtml = mdHtml.replace(/(\b(?:src|href|data-[\w-]+)\s*=\s*)(["'])([^"']+)\2/gi, (_, attr, quote, rawPath) => {
+        _urlAttrRe.lastIndex = 0;
+        mdHtml = mdHtml.replace(_urlAttrRe, (_, attr, quote, rawPath) => {
             if (isProtocolUrl(rawPath))
                 return `${attr}${quote}${rawPath}${quote}`;
 
@@ -194,10 +204,8 @@ QtObject {
             return `${attr}${quote}file://${finalPath}${quote}`;
         });
 
-        //Get original styles
-        var head = html.match(new RegExp("<head>(?:.|\n)*?</head>"))[0];
-        //Add custom styles
-        head = head.replace("</style>", "table {border-spacing: 0; border-style: solid; border-width: 1px; border-collapse: collapse; margin-top: 0.5em;} th, td {padding: 0 5px;} del {text-decoration: line-through;}" + (customStylesheet || "") + "</style>");
+        var head = html.match(_headRe)[0];
+        head = head.replace("</style>", _cssInject + (customStylesheet || "") + "</style>");
         mdHtml = "<html>" + head + "<body>" + mdHtml + "</body></html>";
         return mdHtml;
     }


### PR DESCRIPTION
  After invoking a custom action via keyboard shortcut (e.g. "Heading 2"), the editor lost focus, forcing the user to
   click with the mouse before typing again.

  - Root cause: the toolbar/menu button steals focus when the action fires.
  - First attempt: script.noteTextEditSetFocus() — does not exist, throws TypeError on v26.5.14.
  - Fix: mainWindow.focusNoteTextEdit() added at the end of customActionInvoked(). This is the only official API method for restoring editor focus.

noteToMarkdownHtmlHook optimisations (hot path, called on every keystroke):
  - _isWindows — platformIsWindows() cached in init() (avoids an external call on every render)
  - _headRe — regex /<head>[\s\S]*?<\/head>/ pre-compiled in init() (no more new RegExp(...) on each call + (?:.|\n)*? replaced by [\s\S]*? which is significantly faster on large HTML)
  - _urlAttrRe — URL attribute regex pre-compiled in init() + lastIndex = 0 reset before each replace()
  - _cssInject — constant CSS string extracted as a property

txt2tags_autolink optimisation (inline rule, called at every position):
  - charCode fast-fail before src.slice(pos) + exec() — avoids creating a substring for every / and any non-letter character